### PR TITLE
Xml support

### DIFF
--- a/AnySerializer/AnySerializer.Tests/AnySerializer.Tests.csproj
+++ b/AnySerializer/AnySerializer.Tests/AnySerializer.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;net40;net45;net46;net461;net462;net47</TargetFrameworks>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/AnySerializer/AnySerializer.Tests/AnySerializer.Tests.csproj
+++ b/AnySerializer/AnySerializer.Tests/AnySerializer.Tests.csproj
@@ -25,6 +25,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="TestData\basic.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="TestData\basic.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />

--- a/AnySerializer/AnySerializer.Tests/AnySerializer.Tests.csproj
+++ b/AnySerializer/AnySerializer.Tests/AnySerializer.Tests.csproj
@@ -31,12 +31,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="TestData\complex.xml">
+    <EmbeddedResource Include="TestData\complex.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="TestData\basic.xml">
+    </EmbeddedResource>
+    <EmbeddedResource Include="TestData\basic.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/AnySerializer/AnySerializer.Tests/AnySerializer.Tests.csproj
+++ b/AnySerializer/AnySerializer.Tests/AnySerializer.Tests.csproj
@@ -26,9 +26,13 @@
 
   <ItemGroup>
     <None Remove="TestData\basic.xml" />
+    <None Remove="TestData\complex.xml" />
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="TestData\complex.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestData\basic.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/AnySerializer/AnySerializer.Tests/IgnoreTests.cs
+++ b/AnySerializer/AnySerializer.Tests/IgnoreTests.cs
@@ -77,8 +77,8 @@ namespace AnySerializer.Tests
         {
             var test = new BasicObject { Id = 1, Description = "Description", IsEnabled = true };
             var provider = new SerializerProvider();
-            var bytes = provider.Serialize(test, ".Description");
-            var testDeserialized = provider.Deserialize<BasicObject>(bytes, "Description");
+            var bytes = provider.Serialize(test, ".BasicObject.Description");
+            var testDeserialized = provider.Deserialize<BasicObject>(bytes, ".BasicObject.Description");
             Assert.AreEqual(test.Id, testDeserialized.Id);
             Assert.AreEqual(test.IsEnabled, testDeserialized.IsEnabled);
             Assert.IsNull(testDeserialized.Description);
@@ -101,8 +101,8 @@ namespace AnySerializer.Tests
         {
             var test = new BasicObject { Id = 1, Description = "Description", IsEnabled = true };
             var provider = new SerializerProvider();
-            var bytes = provider.Serialize(test, ".<Description>k__BackingField");
-            var testDeserialized = provider.Deserialize<BasicObject>(bytes, ".<Description>k__BackingField");
+            var bytes = provider.Serialize(test, ".BasicObject.<Description>k__BackingField");
+            var testDeserialized = provider.Deserialize<BasicObject>(bytes, ".BasicObject.<Description>k__BackingField");
             Assert.AreEqual(test.Id, testDeserialized.Id);
             Assert.AreEqual(test.IsEnabled, testDeserialized.IsEnabled);
             Assert.IsNull(testDeserialized.Description);

--- a/AnySerializer/AnySerializer.Tests/StructTests.cs
+++ b/AnySerializer/AnySerializer.Tests/StructTests.cs
@@ -1,0 +1,31 @@
+﻿using AnySerializer.Tests.TestObjects;
+using NUnit.Framework;
+
+namespace AnySerializer.Tests
+{
+    [TestFixture]
+    public class StructTests
+    {
+        [Test]
+        public void Should_Deserialize_Struct()
+        {
+            var test = new StructObject(1, 50);
+            var provider = new SerializerProvider();
+            var bytes = provider.Serialize(test);
+            var deserializedTest = provider.Deserialize<StructObject>(bytes);
+
+            Assert.AreEqual(test, deserializedTest);
+        }
+
+        [Test]
+        public void Should_Deserialize_RecursiveStruct()
+        {
+            var test = new RecursiveStructObject(1);
+            var provider = new SerializerProvider();
+            var bytes = provider.Serialize(test);
+            var deserializedTest = provider.Deserialize<RecursiveStructObject>(bytes);
+
+            Assert.AreEqual(test, deserializedTest);
+        }
+    }
+}

--- a/AnySerializer/AnySerializer.Tests/TestData/basic.xml
+++ b/AnySerializer/AnySerializer.Tests/TestData/basic.xml
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<letter>
+  <title maxlength="10"> Quote Letter </title>
+  <salutation limit="40">Dear Daniel,</salutation>
+  <text>
+    Thank you f or sending us the information on <emphasis>SDL Trados Studio 2009</emphasis>.
+
+    We like your products and think they certainly represent the most powerful translation solution on the market.
+
+    We especially like the <component translate="yes">XML Parser rules</component> options in the <component translate="no">XML</component> filter.
+
+    It has helped us to set up support for our XML files in a flash.
+
+    We have already downloaded the latest version from your Customer Center.
+  </text>
+  <title maxlength="40"> Quote Details </title>
+  <text>
+    We would like to order 50 licenses.
+    Please send us a quote. Keep up the good work!
+  </text>
+  <greetings minlength="10">Yours sincerely,</greetings>
+  <signature> Paul Smith</signature>
+  <address translate="yes">Smith &amp; Company Ltd.</address>
+  <address translate="no">Smithtown</address>
+  <weblink>http://www.smith-company-ltd.com</weblink>
+  <logo alt="Logo of Smith and Company Ltd." address="http://www.smith-company-ltd.com/logo.jpg"/>
+</letter>

--- a/AnySerializer/AnySerializer.Tests/TestData/basic.xml
+++ b/AnySerializer/AnySerializer.Tests/TestData/basic.xml
@@ -1,27 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <letter>
-  <title maxlength="10"> Quote Letter </title>
-  <salutation limit="40">Dear Daniel,</salutation>
+  <title maxlength="10">Test Title</title>
   <text>
-    Thank you f or sending us the information on <emphasis>SDL Trados Studio 2009</emphasis>.
-
-    We like your products and think they certainly represent the most powerful translation solution on the market.
-
-    We especially like the <component translate="yes">XML Parser rules</component> options in the <component translate="no">XML</component> filter.
-
-    It has helped us to set up support for our XML files in a flash.
-
-    We have already downloaded the latest version from your Customer Center.
+    This is a test object text.
   </text>
-  <title maxlength="40"> Quote Details </title>
-  <text>
-    We would like to order 50 licenses.
-    Please send us a quote. Keep up the good work!
-  </text>
-  <greetings minlength="10">Yours sincerely,</greetings>
-  <signature> Paul Smith</signature>
-  <address translate="yes">Smith &amp; Company Ltd.</address>
-  <address translate="no">Smithtown</address>
-  <weblink>http://www.smith-company-ltd.com</weblink>
-  <logo alt="Logo of Smith and Company Ltd." address="http://www.smith-company-ltd.com/logo.jpg"/>
 </letter>

--- a/AnySerializer/AnySerializer.Tests/TestData/complex.xml
+++ b/AnySerializer/AnySerializer.Tests/TestData/complex.xml
@@ -1,0 +1,1203 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<records>
+  <record>
+    <Test>Harlan</Test>
+    <Phone>1-464-874-8344</Phone>
+    <Address>P.O. Box 953, 2101 Vulputate, Av.</Address>
+    <City>Cork</City>
+    <State>M</State>
+    <Country>Faroe Islands</Country>
+    <Email>mus.Proin.vel@egetmetuseu.co.uk</Email>
+    <Company>Lectus Cum Corp.</Company>
+    <Id>1D36AE33-FAB8-F542-5DEE-A8DA4D636782</Id>
+    <Location>-71.0999, 54.70481</Location>
+  </record>
+  <record>
+    <Test>Grady</Test>
+    <Phone>1-243-567-0114</Phone>
+    <Address>365-6449 A, Street</Address>
+    <City>Shimoga</City>
+    <State>Karnataka</State>
+    <Country>Andorra</Country>
+    <Email>Mauris.molestie.pharetra@ametrisusDonec.edu</Email>
+    <Company>Lectus Rutrum Urna Foundation</Company>
+    <Id>ECD8D9CE-D65F-8B3D-6D3B-922FFF63A547</Id>
+    <Location>-7.17307, 1.13244</Location>
+  </record>
+  <record>
+    <Test>Reuben</Test>
+    <Phone>1-633-322-9573</Phone>
+    <Address>584-5906 Ipsum Av.</Address>
+    <City>Tiruvarur</City>
+    <State>Tamil Nadu</State>
+    <Country>Japan</Country>
+    <Email>ac@velitQuisquevarius.net</Email>
+    <Company>Hendrerit Inc.</Company>
+    <Id>5098390C-34F6-470F-EBDA-87E2F0CCE3F4</Id>
+    <Location>-75.23649, -177.72461</Location>
+  </record>
+  <record>
+    <Test>Neil</Test>
+    <Phone>1-290-398-4846</Phone>
+    <Address>P.O. Box 741, 7858 Tellus Rd.</Address>
+    <City>Tilburg</City>
+    <State>N.</State>
+    <Country>Eritrea</Country>
+    <Email>aliquet.odio.Etiam@enim.ca</Email>
+    <Company>Commodo Tincidunt Limited</Company>
+    <Id>A06AE29E-8641-EB84-F695-546FFD8BB354</Id>
+    <Location>62.21528, 93.65285</Location>
+  </record>
+  <record>
+    <Test>Price</Test>
+    <Phone>1-575-479-1155</Phone>
+    <Address>P.O. Box 771, 2040 Vestibulum Ave</Address>
+    <City>Sonnino</City>
+    <State>LAZ</State>
+    <Country>Botswana</Country>
+    <Email>id.ante.Nunc@semperpretium.org</Email>
+    <Company>Cras Eu Company</Company>
+    <Id>786EA78A-5809-CEEE-CF7E-1A165C9A921D</Id>
+    <Location>29.91682, 127.1085</Location>
+  </record>
+  <record>
+    <Test>Simon</Test>
+    <Phone>1-626-329-5977</Phone>
+    <Address>Ap #201-6753 Dolor. Avenue</Address>
+    <City>Balsas</City>
+    <State>MA</State>
+    <Country>Mauritania</Country>
+    <Email>scelerisque.mollis@neceuismodin.co.uk</Email>
+    <Company>Lobortis LLP</Company>
+    <Id>186C3D6E-BBEC-7E64-775B-91FF498DE02A</Id>
+    <Location>-54.26595, -171.67385</Location>
+  </record>
+  <record>
+    <Test>Cruz</Test>
+    <Phone>1-630-472-5602</Phone>
+    <Address>7317 Auctor Rd.</Address>
+    <City>Bear</City>
+    <State>DE</State>
+    <Country>Mauritius</Country>
+    <Email>fames@rhoncusidmollis.net</Email>
+    <Company>Hendrerit Id Ante PC</Company>
+    <Id>D30EDE45-3E87-134B-8394-F093A2449EC5</Id>
+    <Location>7.18172, 159.55727</Location>
+  </record>
+  <record>
+    <Test>Chester</Test>
+    <Phone>1-799-494-6154</Phone>
+    <Address>Ap #937-9954 Parturient Rd.</Address>
+    <City>Pudukkottai</City>
+    <State>Tamil Nadu</State>
+    <Country>Solomon Islands</Country>
+    <Email>nunc.ac@mauris.ca</Email>
+    <Company>Nibh LLP</Company>
+    <Id>7B81A408-6C78-2DD2-8074-5859F5D1BCE5</Id>
+    <Location>-23.93991, 37.50839</Location>
+  </record>
+  <record>
+    <Test>Benedict</Test>
+    <Phone>1-285-676-8193</Phone>
+    <Address>5333 Praesent Road</Address>
+    <City>Rockville</City>
+    <State>Maryland</State>
+    <Country>France</Country>
+    <Email>nibh.Donec@erategetipsum.ca</Email>
+    <Company>Malesuada Fringilla Est LLC</Company>
+    <Id>DF7BB6E7-96C3-BA0A-D307-6A79C2F73951</Id>
+    <Location>79.82158, -156.86373</Location>
+  </record>
+  <record>
+    <Test>Dorian</Test>
+    <Phone>1-118-125-4765</Phone>
+    <Address>Ap #537-2631 Fringilla St.</Address>
+    <City>Piotrków Trybunalski</City>
+    <State>łódzkie</State>
+    <Country>Canada</Country>
+    <Email>scelerisque.sed@nonmagnaNam.co.uk</Email>
+    <Company>Orci Foundation</Company>
+    <Id>1B2FB993-C78B-1131-AF55-94A4B115BDE6</Id>
+    <Location>-62.85666, -28.0196</Location>
+  </record>
+  <record>
+    <Test>Michael</Test>
+    <Phone>1-332-606-9755</Phone>
+    <Address>961-8508 Convallis, Avenue</Address>
+    <City>Sousa</City>
+    <State>PB</State>
+    <Country>Egypt</Country>
+    <Email>velit@conguea.co.uk</Email>
+    <Company>Aliquam LLP</Company>
+    <Id>BA976F50-2728-7E42-8E14-FAD96D26D9A2</Id>
+    <Location>86.02543, 155.09016</Location>
+  </record>
+  <record>
+    <Test>Drew</Test>
+    <Phone>1-663-125-9782</Phone>
+    <Address>5257 Eget Ave</Address>
+    <City>Bama</City>
+    <State>Borno</State>
+    <Country>Egypt</Country>
+    <Email>Etiam.laoreet.libero@feugiatmetus.ca</Email>
+    <Company>Amet Consectetuer Adipiscing Ltd</Company>
+    <Id>E6B7C621-C410-C14A-2A29-A4063C4E4BD4</Id>
+    <Location>-14.95951, -127.91359</Location>
+  </record>
+  <record>
+    <Test>Harrison</Test>
+    <Phone>1-644-894-1645</Phone>
+    <Address>838-7913 Donec St.</Address>
+    <City>Málaga</City>
+    <State>AN</State>
+    <Country>Cambodia</Country>
+    <Email>Aliquam@parturientmontesnascetur.net</Email>
+    <Company>Nibh Enim Gravida PC</Company>
+    <Id>E1445998-404E-D264-2E24-B612FB9A0A89</Id>
+    <Location>71.55473, 73.93087</Location>
+  </record>
+  <record>
+    <Test>Hilel</Test>
+    <Phone>1-860-477-7688</Phone>
+    <Address>4093 Sed Road</Address>
+    <City>Vetlanda</City>
+    <State>F</State>
+    <Country>French Guiana</Country>
+    <Email>euismod@Suspendissealiquetmolestie.net</Email>
+    <Company>Enim Institute</Company>
+    <Id>37B37673-4355-2B2B-8002-544F1E61EE36</Id>
+    <Location>65.89889, -84.9571</Location>
+  </record>
+  <record>
+    <Test>Raphael</Test>
+    <Phone>1-293-865-3159</Phone>
+    <Address>7512 Turpis. St.</Address>
+    <City>West Valley City</City>
+    <State>UT</State>
+    <Country>Bonaire, Sint Eustatius and Saba</Country>
+    <Email>orci.Ut.sagittis@dictumeu.edu</Email>
+    <Company>Magnis Dis Corporation</Company>
+    <Id>0286DD09-012D-A376-63E1-CACE851F2EB0</Id>
+    <Location>75.06427, 2.26125</Location>
+  </record>
+  <record>
+    <Test>Amir</Test>
+    <Phone>1-660-657-1033</Phone>
+    <Address>P.O. Box 178, 2554 Eu, Street</Address>
+    <City>Jodhpur</City>
+    <State>RJ</State>
+    <Country>Mayotte</Country>
+    <Email>tincidunt.tempus@auctorodioa.net</Email>
+    <Company>Ornare Lectus Limited</Company>
+    <Id>95419546-A042-9EF0-699F-A44BCAF03DC7</Id>
+    <Location>-70.04207, -46.16939</Location>
+  </record>
+  <record>
+    <Test>Yoshio</Test>
+    <Phone>1-647-367-6456</Phone>
+    <Address>P.O. Box 626, 3732 Mauris, Street</Address>
+    <City>Vienna</City>
+    <State>Wie</State>
+    <Country>Togo</Country>
+    <Email>imperdiet.non.vestibulum@sit.org</Email>
+    <Company>Nulla Tempor Augue Industries</Company>
+    <Id>B1D1268F-A867-ACD7-E788-6AFD0E1406F4</Id>
+    <Location>-27.46343, -76.00659</Location>
+  </record>
+  <record>
+    <Test>Uriah</Test>
+    <Phone>1-437-931-4961</Phone>
+    <Address>Ap #557-7951 Dictum Ave</Address>
+    <City>Vienna</City>
+    <State>Vienna</State>
+    <Country>Mali</Country>
+    <Email>in.consequat.enim@Proin.ca</Email>
+    <Company>Mi Tempor Lorem LLC</Company>
+    <Id>539B6555-0EC8-CD4E-0DAD-A66194F0C663</Id>
+    <Location>17.1473, 49.19933</Location>
+  </record>
+  <record>
+    <Test>Neil</Test>
+    <Phone>1-363-290-4966</Phone>
+    <Address>5722 Mauris Ave</Address>
+    <City>Camaragibe</City>
+    <State>Pernambuco</State>
+    <Country>Bonaire, Sint Eustatius and Saba</Country>
+    <Email>Cras@magnaPhasellusdolor.ca</Email>
+    <Company>Sed Foundation</Company>
+    <Id>EE577AF3-871A-6CA2-9723-36E4A3421217</Id>
+    <Location>-2.12187, 50.49055</Location>
+  </record>
+  <record>
+    <Test>Zeus</Test>
+    <Phone>1-313-112-6688</Phone>
+    <Address>744-3487 Faucibus Rd.</Address>
+    <City>Chicago</City>
+    <State>Illinois</State>
+    <Country>Luxembourg</Country>
+    <Email>pede.Suspendisse@estac.edu</Email>
+    <Company>A Consulting</Company>
+    <Id>50D73E39-603F-BCAA-586B-DFA074357BCA</Id>
+    <Location>33.49312, -99.41389</Location>
+  </record>
+  <record>
+    <Test>Jason</Test>
+    <Phone>1-791-914-5577</Phone>
+    <Address>P.O. Box 496, 5220 Turpis. Ave</Address>
+    <City>Motala</City>
+    <State>Östergötlands län</State>
+    <Country>Swaziland</Country>
+    <Email>senectus.et.netus@feugiat.net</Email>
+    <Company>Nulla Corp.</Company>
+    <Id>16A68D76-9D5C-15A4-88F4-2340755B57C2</Id>
+    <Location>-6.46408, -152.29728</Location>
+  </record>
+  <record>
+    <Test>Asher</Test>
+    <Phone>1-782-387-8451</Phone>
+    <Address>Ap #794-7940 Aliquam St.</Address>
+    <City>Tilburg</City>
+    <State>Noord Brabant</State>
+    <Country>Norway</Country>
+    <Email>malesuada@infelis.ca</Email>
+    <Company>Adipiscing Non Luctus Company</Company>
+    <Id>C8636335-E069-5D2B-46D2-3E1ECA54BBFD</Id>
+    <Location>73.91724, -31.93586</Location>
+  </record>
+  <record>
+    <Test>Amos</Test>
+    <Phone>1-628-280-6099</Phone>
+    <Address>3744 Dui Av.</Address>
+    <City>Vienna</City>
+    <State>Vienna</State>
+    <Country>Netherlands</Country>
+    <Email>vitae.aliquam.eros@Aenean.com</Email>
+    <Company>Aenean Massa Corporation</Company>
+    <Id>E7FEAF34-4D81-2840-63E7-A41E3FAB146D</Id>
+    <Location>81.22927, 157.72372</Location>
+  </record>
+  <record>
+    <Test>Arsenio</Test>
+    <Phone>1-150-317-5601</Phone>
+    <Address>P.O. Box 542, 5533 Felis Avenue</Address>
+    <City>Enschede</City>
+    <State>Overijssel</State>
+    <Country>Saint Barthélemy</Country>
+    <Email>neque.Sed.eget@eratnequenon.net</Email>
+    <Company>Gravida Institute</Company>
+    <Id>1771B81C-DA40-CE74-1964-FD35308531EE</Id>
+    <Location>-38.16565, 37.49604</Location>
+  </record>
+  <record>
+    <Test>Nicholas</Test>
+    <Phone>1-632-358-8086</Phone>
+    <Address>Ap #604-6671 Mauris Ave</Address>
+    <City>Bouwel</City>
+    <State>Antwerpen</State>
+    <Country>Malawi</Country>
+    <Email>nunc.Quisque@nibhsit.ca</Email>
+    <Company>Vulputate Mauris Corp.</Company>
+    <Id>F3A2F129-3CAA-BA2C-4830-0C434CCADDC3</Id>
+    <Location>14.47855, -140.25339</Location>
+  </record>
+  <record>
+    <Test>Clayton</Test>
+    <Phone>1-447-830-1182</Phone>
+    <Address>Ap #719-7259 Morbi Rd.</Address>
+    <City>Dublin</City>
+    <State>Leinster</State>
+    <Country>Reunion</Country>
+    <Email>dictum@Integer.ca</Email>
+    <Company>Urna Justo Inc.</Company>
+    <Id>58BD0C8E-0C5A-A48C-8120-A54715B2C4EA</Id>
+    <Location>35.22503, 81.79285</Location>
+  </record>
+  <record>
+    <Test>Connor</Test>
+    <Phone>1-807-153-4756</Phone>
+    <Address>5461 Phasellus Av.</Address>
+    <City>Dublin</City>
+    <State>Leinster</State>
+    <Country>Madagascar</Country>
+    <Email>litora.torquent.per@bibendumfermentum.org</Email>
+    <Company>Morbi Industries</Company>
+    <Id>6494D32E-D497-43F1-E8AB-F19A1B7EF7DF</Id>
+    <Location>-13.15537, -38.73691</Location>
+  </record>
+  <record>
+    <Test>Thor</Test>
+    <Phone>1-766-431-3772</Phone>
+    <Address>241-3981 Nostra, Av.</Address>
+    <City>Wigtown</City>
+    <State>Wigtownshire</State>
+    <Country>Libya</Country>
+    <Email>dictum.eu@sapien.co.uk</Email>
+    <Company>Nulla Vulputate Dui Ltd</Company>
+    <Id>92047565-A4A6-738C-426C-D7A4523B128A</Id>
+    <Location>-88.72892, 116.51221</Location>
+  </record>
+  <record>
+    <Test>Joel</Test>
+    <Phone>1-926-801-5371</Phone>
+    <Address>941 Risus, Rd.</Address>
+    <City>Welland</City>
+    <State>ON</State>
+    <Country>Norfolk Island</Country>
+    <Email>aliquet.lobortis.nisi@habitantmorbi.net</Email>
+    <Company>Vel Vulputate PC</Company>
+    <Id>FEED1E3C-BE96-17EF-1CBF-79BBAF018200</Id>
+    <Location>31.92714, 3.79575</Location>
+  </record>
+  <record>
+    <Test>Raymond</Test>
+    <Phone>1-968-856-2548</Phone>
+    <Address>P.O. Box 681, 6882 Ligula Rd.</Address>
+    <City>Vanier</City>
+    <State>ON</State>
+    <Country>Indonesia</Country>
+    <Email>egestas.Aliquam@mauris.net</Email>
+    <Company>Luctus Felis Purus PC</Company>
+    <Id>5314EEDB-50FE-E25F-EDD7-DAE2F587A8CD</Id>
+    <Location>30.96108, 175.9902</Location>
+  </record>
+  <record>
+    <Test>Calvin</Test>
+    <Phone>1-598-448-0780</Phone>
+    <Address>154-9843 Velit Rd.</Address>
+    <City>Dublin</City>
+    <State>Leinster</State>
+    <Country>Gambia</Country>
+    <Email>senectus.et.netus@estacmattis.co.uk</Email>
+    <Company>Et Ipsum Cursus Foundation</Company>
+    <Id>18DE16CB-74EF-D7A2-A762-979390EFC3CE</Id>
+    <Location>-53.55308, 6.96207</Location>
+  </record>
+  <record>
+    <Test>Guy</Test>
+    <Phone>1-240-944-7561</Phone>
+    <Address>P.O. Box 681, 8189 Nec, Ave</Address>
+    <City>Aserrí</City>
+    <State>San José</State>
+    <Country>Japan</Country>
+    <Email>mattis.velit@sollicitudinadipiscing.co.uk</Email>
+    <Company>Sed Pede Cum Limited</Company>
+    <Id>FF3A0E76-D59B-8BD0-FA0B-F69CFA982FEC</Id>
+    <Location>-61.28184, 47.84175</Location>
+  </record>
+  <record>
+    <Test>Brett</Test>
+    <Phone>1-949-512-6170</Phone>
+    <Address>5046 Lacus. St.</Address>
+    <City>Grave</City>
+    <State>N.</State>
+    <Country>Costa Rica</Country>
+    <Email>ad.litora@Sed.org</Email>
+    <Company>Turpis Egestas Ltd</Company>
+    <Id>8C4DD0E3-A289-ED44-8B3D-3A1CA1B816FD</Id>
+    <Location>-60.44666, -100.30469</Location>
+  </record>
+  <record>
+    <Test>Carl</Test>
+    <Phone>1-264-918-2319</Phone>
+    <Address>P.O. Box 673, 7559 Orci Av.</Address>
+    <City>Palmerston North</City>
+    <State>NI</State>
+    <Country>Guernsey</Country>
+    <Email>interdum@nuncQuisqueornare.org</Email>
+    <Company>Proin Dolor Institute</Company>
+    <Id>FF2BBDCE-53F3-7C1A-26CA-01E2562872B2</Id>
+    <Location>3.1654, 114.41417</Location>
+  </record>
+  <record>
+    <Test>Steven</Test>
+    <Phone>1-180-948-6235</Phone>
+    <Address>Ap #924-8011 Sollicitudin St.</Address>
+    <City>Toruń</City>
+    <State>KP</State>
+    <Country>Northern Mariana Islands</Country>
+    <Email>id.magna@gravidaAliquam.ca</Email>
+    <Company>Posuere At Velit Foundation</Company>
+    <Id>3C9B0581-0824-14A7-3C44-92818B9A9AED</Id>
+    <Location>-8.36976, -169.2282</Location>
+  </record>
+  <record>
+    <Test>Marvin</Test>
+    <Phone>1-330-391-0216</Phone>
+    <Address>450-3692 Mauris Ave</Address>
+    <City>Puntarenas</City>
+    <State>Puntarenas</State>
+    <Country>Belarus</Country>
+    <Email>scelerisque.dui@dolorNullasemper.co.uk</Email>
+    <Company>Ut Ltd</Company>
+    <Id>FB918DAC-F7EA-8B98-B2FD-94A769230A7E</Id>
+    <Location>-59.01334, -97.13132</Location>
+  </record>
+  <record>
+    <Test>Orlando</Test>
+    <Phone>1-749-716-6176</Phone>
+    <Address>Ap #452-7758 Lacus, St.</Address>
+    <City>Toledo</City>
+    <State>CM</State>
+    <Country>Guyana</Country>
+    <Email>imperdiet.non.vestibulum@erosnectellus.org</Email>
+    <Company>Lacus Institute</Company>
+    <Id>8F2B9077-D311-208D-538A-F870D72304A8</Id>
+    <Location>26.82444, 139.23262</Location>
+  </record>
+  <record>
+    <Test>Simon</Test>
+    <Phone>1-218-812-6435</Phone>
+    <Address>962-2851 Lorem, Ave</Address>
+    <City>Putaendo</City>
+    <State>V</State>
+    <Country>Cocos (Keeling) Islands</Country>
+    <Email>dolor.dolor.tempus@atortorNunc.net</Email>
+    <Company>Cum Sociis Incorporated</Company>
+    <Id>6E778E7E-5B91-305C-1DDF-246FE249BFD5</Id>
+    <Location>67.0793, 60.78545</Location>
+  </record>
+  <record>
+    <Test>Nash</Test>
+    <Phone>1-281-102-6009</Phone>
+    <Address>Ap #993-3258 Quam Ave</Address>
+    <City>Fortaleza</City>
+    <State>CE</State>
+    <Country>Guinea</Country>
+    <Email>pharetra@tincidunt.net</Email>
+    <Company>Nam Interdum Enim Limited</Company>
+    <Id>4C670C65-8E86-8CF0-DDF5-BDCB8BC21182</Id>
+    <Location>-37.9207, 97.33815</Location>
+  </record>
+  <record>
+    <Test>Jason</Test>
+    <Phone>1-146-369-8727</Phone>
+    <Address>P.O. Box 446, 5392 Orci, Av.</Address>
+    <City>Saguenay</City>
+    <State>QC</State>
+    <Country>French Southern Territories</Country>
+    <Email>ac.mattis@mollisIntegertincidunt.edu</Email>
+    <Company>Sodales Consulting</Company>
+    <Id>EB2EE0F9-8686-684C-9190-62A5157D1DEB</Id>
+    <Location>29.36923, -169.76478</Location>
+  </record>
+  <record>
+    <Test>Erasmus</Test>
+    <Phone>1-578-843-6570</Phone>
+    <Address>942-9785 Proin Avenue</Address>
+    <City>Te Puke</City>
+    <State>North Island</State>
+    <Country>Aruba</Country>
+    <Email>ipsum.Suspendisse.non@loremsitamet.co.uk</Email>
+    <Company>Egestas Aliquam Nec Company</Company>
+    <Id>4329068C-50D5-877E-2A30-7CA1C70C1681</Id>
+    <Location>14.42768, 16.08661</Location>
+  </record>
+  <record>
+    <Test>Emery</Test>
+    <Phone>1-448-970-8481</Phone>
+    <Address>P.O. Box 594, 3496 Non St.</Address>
+    <City>Uyo</City>
+    <State>Akwa Ibom</State>
+    <Country>Algeria</Country>
+    <Email>quis@Donec.co.uk</Email>
+    <Company>Aliquam Adipiscing Lacus Company</Company>
+    <Id>4F32FBC7-5691-A3A5-DE7D-B28105032A5D</Id>
+    <Location>-23.18725, 141.07359</Location>
+  </record>
+  <record>
+    <Test>Christopher</Test>
+    <Phone>1-830-277-3814</Phone>
+    <Address>8086 Dapibus Rd.</Address>
+    <City>Inuvik</City>
+    <State>Northwest Territories</State>
+    <Country>Mongolia</Country>
+    <Email>tempor.est.ac@aenim.com</Email>
+    <Company>Natoque Penatibus Et Inc.</Company>
+    <Id>1F215053-3AF3-8EA1-F303-402C474081E5</Id>
+    <Location>-14.19331, -50.37696</Location>
+  </record>
+  <record>
+    <Test>Stephen</Test>
+    <Phone>1-366-487-0423</Phone>
+    <Address>722-1889 Dolor Av.</Address>
+    <City>Palma de Mallorca</City>
+    <State>BA</State>
+    <Country>Bahrain</Country>
+    <Email>posuere.cubilia.Curae@mollisnon.com</Email>
+    <Company>Elementum Lorem Ut Ltd</Company>
+    <Id>F72ECB8C-0C93-6B02-BA07-90D3C4EF63F8</Id>
+    <Location>8.38269, 86.01535</Location>
+  </record>
+  <record>
+    <Test>Forrest</Test>
+    <Phone>1-649-145-8565</Phone>
+    <Address>8883 Odio Street</Address>
+    <City>Valladolid</City>
+    <State>Castilla y León</State>
+    <Country>Guinea-Bissau</Country>
+    <Email>ornare.lectus@risus.ca</Email>
+    <Company>Justo LLC</Company>
+    <Id>A0C593AD-8214-EF15-6BBD-F3BD7E7CEA27</Id>
+    <Location>61.92063, -156.59104</Location>
+  </record>
+  <record>
+    <Test>Lars</Test>
+    <Phone>1-704-420-8129</Phone>
+    <Address>Ap #601-7852 Ipsum Rd.</Address>
+    <City>Cartago</City>
+    <State>C</State>
+    <Country>South Sudan</Country>
+    <Email>fringilla.porttitor.vulputate@diamvelarcu.org</Email>
+    <Company>Fusce Foundation</Company>
+    <Id>69C7C439-A267-2F83-079D-0D9C9EB18746</Id>
+    <Location>-34.12121, -165.66642</Location>
+  </record>
+  <record>
+    <Test>Henry</Test>
+    <Phone>1-465-707-6384</Phone>
+    <Address>P.O. Box 587, 8438 Conubia Av.</Address>
+    <City>Warszawa</City>
+    <State>Mazowieckie</State>
+    <Country>Chile</Country>
+    <Email>sem.Pellentesque@lobortis.com</Email>
+    <Company>Non Justo Limited</Company>
+    <Id>AD468F17-7A79-DCBF-E809-77448D646957</Id>
+    <Location>82.25304, 66.04251</Location>
+  </record>
+  <record>
+    <Test>Jasper</Test>
+    <Phone>1-285-718-4677</Phone>
+    <Address>6159 Elit, St.</Address>
+    <City>Campinas</City>
+    <State>SP</State>
+    <Country>United Kingdom (Great Britain)</Country>
+    <Email>arcu@urna.com</Email>
+    <Company>Adipiscing Ligula Aenean Foundation</Company>
+    <Id>5A2AF103-76E7-597C-6A00-E1AADD62DBF8</Id>
+    <Location>-44.36865, 169.12521</Location>
+  </record>
+  <record>
+    <Test>Caleb</Test>
+    <Phone>1-159-272-0849</Phone>
+    <Address>577-6068 Imperdiet Street</Address>
+    <City>Cheyenne</City>
+    <State>Wyoming</State>
+    <Country>American Samoa</Country>
+    <Email>dignissim.tempor@vitaesodales.com</Email>
+    <Company>Enim Mauris Quis Industries</Company>
+    <Id>4B6662A4-1984-587A-5498-C2EA50AB1D92</Id>
+    <Location>-38.87853, -45.113</Location>
+  </record>
+  <record>
+    <Test>Tyler</Test>
+    <Phone>1-716-121-1881</Phone>
+    <Address>P.O. Box 148, 8213 A, Av.</Address>
+    <City>Melton Mowbray</City>
+    <State>LE</State>
+    <Country>Poland</Country>
+    <Email>Cras.dictum.ultricies@Maurisvelturpis.org</Email>
+    <Company>Ante Nunc Mauris Associates</Company>
+    <Id>6D1072C0-12AA-14C5-E28C-1AE6D03EF416</Id>
+    <Location>16.71555, -131.68618</Location>
+  </record>
+  <record>
+    <Test>Lance</Test>
+    <Phone>1-269-657-7031</Phone>
+    <Address>Ap #223-8893 Dictum Rd.</Address>
+    <City>Radom</City>
+    <State>MA</State>
+    <Country>Saint Lucia</Country>
+    <Email>dui@utnullaCras.co.uk</Email>
+    <Company>Adipiscing Limited</Company>
+    <Id>7EE69FD4-0EAD-A439-8EA4-F96419AB23D1</Id>
+    <Location>-57.94034, -66.3987</Location>
+  </record>
+  <record>
+    <Test>Flynn</Test>
+    <Phone>1-536-308-9670</Phone>
+    <Address>Ap #462-4040 Eget Rd.</Address>
+    <City>Joué-lès-Tours</City>
+    <State>Centre</State>
+    <Country>Mayotte</Country>
+    <Email>erat.Etiam@posuere.edu</Email>
+    <Company>Dui In Corp.</Company>
+    <Id>E7E8FC04-A050-2951-46B4-246AE35997AD</Id>
+    <Location>-66.03345, -116.51777</Location>
+  </record>
+  <record>
+    <Test>Colorado</Test>
+    <Phone>1-488-781-3642</Phone>
+    <Address>8270 Malesuada Av.</Address>
+    <City>Naarden</City>
+    <State>N.</State>
+    <Country>Central African Republic</Country>
+    <Email>enim@urnaconvalliserat.net</Email>
+    <Company>Ultricies Ligula Nullam Corp.</Company>
+    <Id>A055E3D3-FDC9-8261-F4D6-E6F7DA7A83EE</Id>
+    <Location>89.75567, -124.00768</Location>
+  </record>
+  <record>
+    <Test>Barclay</Test>
+    <Phone>1-517-625-1040</Phone>
+    <Address>P.O. Box 844, 850 Augue Road</Address>
+    <City>Vienna</City>
+    <State>Vienna</State>
+    <Country>Ethiopia</Country>
+    <Email>enim.Etiam@purusinmolestie.ca</Email>
+    <Company>Egestas Sed Pharetra Limited</Company>
+    <Id>FE5F92EC-84CB-0726-4F3E-B8E2F548F83E</Id>
+    <Location>67.09417, -71.92914</Location>
+  </record>
+  <record>
+    <Test>Timothy</Test>
+    <Phone>1-819-255-3892</Phone>
+    <Address>582-1542 Morbi Rd.</Address>
+    <City>Warwick</City>
+    <State>Ontario</State>
+    <Country>Bonaire, Sint Eustatius and Saba</Country>
+    <Email>magna.a.neque@porttitorvulputateposuere.org</Email>
+    <Company>Lacus Company</Company>
+    <Id>6AC067A3-E1B3-5477-0362-F03D2843FC82</Id>
+    <Location>-55.40181, -51.45145</Location>
+  </record>
+  <record>
+    <Test>Ahmed</Test>
+    <Phone>1-934-210-1584</Phone>
+    <Address>7846 Fringilla. Avenue</Address>
+    <City>Córdoba</City>
+    <State>AN</State>
+    <Country>Malawi</Country>
+    <Email>interdum.Nunc.sollicitudin@Praesenteunulla.com</Email>
+    <Company>Bibendum Ullamcorper Duis Inc.</Company>
+    <Id>D9438672-7C83-5F90-E409-355DD21F1B52</Id>
+    <Location>45.45936, -21.56877</Location>
+  </record>
+  <record>
+    <Test>Cedric</Test>
+    <Phone>1-163-565-9175</Phone>
+    <Address>621-6696 Lobortis Street</Address>
+    <City>Frankfurt am Main</City>
+    <State>HE</State>
+    <Country>Djibouti</Country>
+    <Email>ultrices.mauris.ipsum@pedeultricesa.org</Email>
+    <Company>Lacus Aliquam Rutrum LLC</Company>
+    <Id>3CB3EFE2-4732-C5C4-85AA-FCEEE57E8FAD</Id>
+    <Location>-79.86581, -54.01511</Location>
+  </record>
+  <record>
+    <Test>Beau</Test>
+    <Phone>1-217-996-2342</Phone>
+    <Address>Ap #679-6345 Donec Rd.</Address>
+    <City>Ipswich</City>
+    <State>QLD</State>
+    <Country>Isle of Man</Country>
+    <Email>Duis.volutpat@congue.co.uk</Email>
+    <Company>Lorem Ipsum Corp.</Company>
+    <Id>845ACE96-31D8-445C-0496-25CB802D799F</Id>
+    <Location>-77.04595, 152.26645</Location>
+  </record>
+  <record>
+    <Test>Raymond</Test>
+    <Phone>1-159-571-5272</Phone>
+    <Address>5329 Integer Av.</Address>
+    <City>Vigo</City>
+    <State>Galicia</State>
+    <Country>Heard Island and Mcdonald Islands</Country>
+    <Email>Ut.sagittis@Vivamuseuismod.co.uk</Email>
+    <Company>Metus In Corporation</Company>
+    <Id>4EA69B69-E621-534A-DC29-C754599DEACC</Id>
+    <Location>88.0566, -139.18775</Location>
+  </record>
+  <record>
+    <Test>Aaron</Test>
+    <Phone>1-204-570-3091</Phone>
+    <Address>799-6733 Lacus. Rd.</Address>
+    <City>Zaltbommel</City>
+    <State>Gelderland</State>
+    <Country>Iceland</Country>
+    <Email>lobortis@vel.org</Email>
+    <Company>Donec Tincidunt Donec Limited</Company>
+    <Id>3CADDF67-7AFE-0156-6E1A-CF69058647F8</Id>
+    <Location>-1.66909, -138.04069</Location>
+  </record>
+  <record>
+    <Test>Aristotle</Test>
+    <Phone>1-184-913-2892</Phone>
+    <Address>918-3748 Accumsan Road</Address>
+    <City>Surendranagar</City>
+    <State>GJ</State>
+    <Country>Germany</Country>
+    <Email>tincidunt@Namnullamagna.edu</Email>
+    <Company>Sit Associates</Company>
+    <Id>D99395B5-D14D-AB65-EAC8-2D2D81CDB7F5</Id>
+    <Location>-10.93821, 1.39688</Location>
+  </record>
+  <record>
+    <Test>Channing</Test>
+    <Phone>1-944-321-8948</Phone>
+    <Address>273-7874 Sed St.</Address>
+    <City>Geertruidenberg</City>
+    <State>Noord Brabant</State>
+    <Country>Tunisia</Country>
+    <Email>dolor@nunc.co.uk</Email>
+    <Company>Nisi Company</Company>
+    <Id>B4A85C8E-5CB2-A78D-BD47-5AA356AF9EC0</Id>
+    <Location>-69.65665, -124.27538</Location>
+  </record>
+  <record>
+    <Test>Talon</Test>
+    <Phone>1-873-257-8915</Phone>
+    <Address>P.O. Box 966, 7685 Malesuada St.</Address>
+    <City>Owerri</City>
+    <State>Imo</State>
+    <Country>Mauritania</Country>
+    <Email>at@ligulatortordictum.ca</Email>
+    <Company>Egestas Limited</Company>
+    <Id>736590A1-96BE-35B8-BBD6-94AA932FAE71</Id>
+    <Location>-29.05174, 69.86084</Location>
+  </record>
+  <record>
+    <Test>Hasad</Test>
+    <Phone>1-185-157-7976</Phone>
+    <Address>251-7628 Mattis Rd.</Address>
+    <City>Groenlo</City>
+    <State>Gl</State>
+    <Country>South Africa</Country>
+    <Email>Quisque.imperdiet@Quisqueornare.edu</Email>
+    <Company>Suspendisse Industries</Company>
+    <Id>5DD635B7-351E-F54C-918B-A8844052FEB5</Id>
+    <Location>-86.40601, 112.97428</Location>
+  </record>
+  <record>
+    <Test>Reese</Test>
+    <Phone>1-772-222-5279</Phone>
+    <Address>805-4679 Libero Ave</Address>
+    <City>Belfast</City>
+    <State>Ulster</State>
+    <Country>Kazakhstan</Country>
+    <Email>Vestibulum@CuraePhasellus.com</Email>
+    <Company>Est Mollis Non Corp.</Company>
+    <Id>CB98DCEA-EF5C-1632-63A0-01AFEAE864AF</Id>
+    <Location>25.37066, -48.07878</Location>
+  </record>
+  <record>
+    <Test>Quinlan</Test>
+    <Phone>1-729-752-7548</Phone>
+    <Address>8828 Nulla St.</Address>
+    <City>Bergen op Zoom</City>
+    <State>Noord Brabant</State>
+    <Country>Cook Islands</Country>
+    <Email>fermentum.vel.mauris@hendreritconsectetuer.co.uk</Email>
+    <Company>Cras Corp.</Company>
+    <Id>817A68EA-51AE-0A86-DD09-7A46ED2025D3</Id>
+    <Location>42.9714, -49.49641</Location>
+  </record>
+  <record>
+    <Test>Keane</Test>
+    <Phone>1-136-749-7252</Phone>
+    <Address>3621 Pellentesque Ave</Address>
+    <City>Peumo</City>
+    <State>VI</State>
+    <Country>Bosnia and Herzegovina</Country>
+    <Email>posuere@nonluctus.co.uk</Email>
+    <Company>Nec Mauris Blandit Institute</Company>
+    <Id>2336ACDB-26BF-FBB9-F543-065577E85D8A</Id>
+    <Location>-79.85958, 73.27098</Location>
+  </record>
+  <record>
+    <Test>Dylan</Test>
+    <Phone>1-852-951-2680</Phone>
+    <Address>P.O. Box 470, 7489 Duis Rd.</Address>
+    <City>Buckingham</City>
+    <State>Quebec</State>
+    <Country>Iran</Country>
+    <Email>Etiam.laoreet.libero@Aenean.edu</Email>
+    <Company>Integer Eu Lacus Corporation</Company>
+    <Id>E74C2AD5-FD2F-63D3-5263-33C73B7DBE33</Id>
+    <Location>-53.53889, -20.28227</Location>
+  </record>
+  <record>
+    <Test>Walker</Test>
+    <Phone>1-808-667-8173</Phone>
+    <Address>735-6404 Integer Road</Address>
+    <City>Winnipeg</City>
+    <State>Manitoba</State>
+    <Country>Iran</Country>
+    <Email>a.scelerisque@inlobortis.net</Email>
+    <Company>Vitae Orci Incorporated</Company>
+    <Id>876C5D69-843D-73BF-34FD-84DED1F1AF1F</Id>
+    <Location>66.60033, -88.25317</Location>
+  </record>
+  <record>
+    <Test>Russell</Test>
+    <Phone>1-110-330-2270</Phone>
+    <Address>P.O. Box 542, 8019 Pellentesque, Street</Address>
+    <City>La Pintana</City>
+    <State>RM</State>
+    <Country>Yemen</Country>
+    <Email>lacus@mauriserateget.edu</Email>
+    <Company>Nisl Nulla Eu Foundation</Company>
+    <Id>E16217D7-751A-76B1-3F4F-4900C824BB88</Id>
+    <Location>-24.20544, 1.16186</Location>
+  </record>
+  <record>
+    <Test>Len</Test>
+    <Phone>1-526-265-6691</Phone>
+    <Address>1437 Proin Av.</Address>
+    <City>Virginia Beach</City>
+    <State>Virginia</State>
+    <Country>Liechtenstein</Country>
+    <Email>Nullam.velit.dui@elit.co.uk</Email>
+    <Company>Convallis Inc.</Company>
+    <Id>E3F8C551-D0FC-8A8F-CD2A-23E7D45D9DF2</Id>
+    <Location>-45.88055, -163.1413</Location>
+  </record>
+  <record>
+    <Test>Abdul</Test>
+    <Phone>1-898-270-1989</Phone>
+    <Address>393-598 Duis St.</Address>
+    <City>Juiz de Fora</City>
+    <State>MG</State>
+    <Country>Slovakia</Country>
+    <Email>tempor.lorem@euismodestarcu.net</Email>
+    <Company>Nibh Lacinia Ltd</Company>
+    <Id>4CD0A6AF-EE17-9075-7A98-AFE64874CBF1</Id>
+    <Location>68.20063, -164.92475</Location>
+  </record>
+  <record>
+    <Test>Daniel</Test>
+    <Phone>1-604-125-5835</Phone>
+    <Address>P.O. Box 795, 5854 Erat St.</Address>
+    <City>Cornwall</City>
+    <State>Ontario</State>
+    <Country>India</Country>
+    <Email>magna.Phasellus@erosnectellus.ca</Email>
+    <Company>Et Ltd</Company>
+    <Id>3B65670E-1F4F-ECE0-BAB6-C8C32B4B6BFD</Id>
+    <Location>-30.52408, -172.87099</Location>
+  </record>
+  <record>
+    <Test>Addison</Test>
+    <Phone>1-729-133-7990</Phone>
+    <Address>1927 Velit Av.</Address>
+    <City>Słupsk</City>
+    <State>PM</State>
+    <Country>Sri Lanka</Country>
+    <Email>non.bibendum@Donectempus.com</Email>
+    <Company>Nibh Vulputate Mauris Industries</Company>
+    <Id>30CC164B-4ED2-DA71-E7B7-2892ED0A619C</Id>
+    <Location>-70.74258, 31.9986</Location>
+  </record>
+  <record>
+    <Test>Hamish</Test>
+    <Phone>1-677-611-1750</Phone>
+    <Address>P.O. Box 277, 2127 Placerat Avenue</Address>
+    <City>Kapiti</City>
+    <State>North Island</State>
+    <Country>British Indian Ocean Territory</Country>
+    <Email>hendrerit.a@interdumNunc.ca</Email>
+    <Company>Etiam Gravida Molestie LLP</Company>
+    <Id>C7AAB8EF-6281-C423-3267-BCDA14636344</Id>
+    <Location>80.91246, -129.14276</Location>
+  </record>
+  <record>
+    <Test>Erich</Test>
+    <Phone>1-725-400-7612</Phone>
+    <Address>Ap #681-3495 Morbi Rd.</Address>
+    <City>Pozo Almonte</City>
+    <State>Tarapacá</State>
+    <Country>Georgia</Country>
+    <Email>erat@sodalesMaurisblandit.com</Email>
+    <Company>Turpis Aliquam Incorporated</Company>
+    <Id>BCEF6DE1-C9E3-34A0-703C-DFF22E53C0BB</Id>
+    <Location>10.92145, -55.44029</Location>
+  </record>
+  <record>
+    <Test>Mason</Test>
+    <Phone>1-697-605-9392</Phone>
+    <Address>Ap #568-8010 In Street</Address>
+    <City>Boston</City>
+    <State>Massachusetts</State>
+    <Country>Morocco</Country>
+    <Email>vitae.dolor.Donec@aliquet.com</Email>
+    <Company>Dolor Quam Elementum LLC</Company>
+    <Id>4D27511E-CE6D-9D9F-94EB-6573AF705C77</Id>
+    <Location>71.02467, 127.64559</Location>
+  </record>
+  <record>
+    <Test>Brennan</Test>
+    <Phone>1-682-770-7422</Phone>
+    <Address>544-6800 Nisi Avenue</Address>
+    <City>San Juan (San Juan de Tibás)</City>
+    <State>San José</State>
+    <Country>Angola</Country>
+    <Email>ac.tellus.Suspendisse@magna.edu</Email>
+    <Company>Magnis Dis Parturient Corp.</Company>
+    <Id>978E3049-05E6-EE27-0F66-B8C5BE541945</Id>
+    <Location>-63.02614, 27.04173</Location>
+  </record>
+  <record>
+    <Test>Finn</Test>
+    <Phone>1-737-988-6032</Phone>
+    <Address>Ap #476-5840 Sed Ave</Address>
+    <City>Côte Saint-Luc</City>
+    <State>QC</State>
+    <Country>Cocos (Keeling) Islands</Country>
+    <Email>tristique.ac@suscipitnonummyFusce.ca</Email>
+    <Company>Gravida Non Institute</Company>
+    <Id>1469F3A3-3DD9-A2F7-301E-E01C0EE2A86A</Id>
+    <Location>27.47499, 95.61449</Location>
+  </record>
+  <record>
+    <Test>Marvin</Test>
+    <Phone>1-234-431-4217</Phone>
+    <Address>979-9576 Taciti Rd.</Address>
+    <City>Penrith</City>
+    <State>New South Wales</State>
+    <Country>Slovakia</Country>
+    <Email>Phasellus.elit.pede@gravidasitamet.net</Email>
+    <Company>Enim Non Nisi Inc.</Company>
+    <Id>5F07CE1F-3E44-4441-8B87-275C78D8BBE7</Id>
+    <Location>76.75497, -64.93642</Location>
+  </record>
+  <record>
+    <Test>Preston</Test>
+    <Phone>1-373-992-7111</Phone>
+    <Address>P.O. Box 513, 2438 Mus. St.</Address>
+    <City>Wodonga</City>
+    <State>Victoria</State>
+    <Country>Timor-Leste</Country>
+    <Email>tristique.pharetra.Quisque@magna.org</Email>
+    <Company>Lobortis Quis Ltd</Company>
+    <Id>BEA53ABE-1B56-E4E1-7299-9E51DF5E9020</Id>
+    <Location>12.69492, 113.97293</Location>
+  </record>
+  <record>
+    <Test>Hedley</Test>
+    <Phone>1-787-913-8121</Phone>
+    <Address>Ap #873-6708 Vel Rd.</Address>
+    <City>Luino</City>
+    <State>LOM</State>
+    <Country>Malaysia</Country>
+    <Email>nunc.ullamcorper.eu@duisemperet.net</Email>
+    <Company>Vulputate Incorporated</Company>
+    <Id>2A946D86-A101-8B57-8DBD-AD171738827A</Id>
+    <Location>-16.5561, -101.3504</Location>
+  </record>
+  <record>
+    <Test>Bradley</Test>
+    <Phone>1-945-681-9303</Phone>
+    <Address>P.O. Box 964, 4028 Felis. St.</Address>
+    <City>Grand Island</City>
+    <State>Nebraska</State>
+    <Country>Palestine, State of</Country>
+    <Email>luctus@turpisnonenim.net</Email>
+    <Company>Ac Incorporated</Company>
+    <Id>114A9DDE-FFBE-0FC9-AA7D-4D51902F753E</Id>
+    <Location>13.9644, 45.64204</Location>
+  </record>
+  <record>
+    <Test>Raymond</Test>
+    <Phone>1-427-229-2834</Phone>
+    <Address>369-4993 Interdum. Street</Address>
+    <City>Perinaldo</City>
+    <State>Liguria</State>
+    <Country>Andorra</Country>
+    <Email>gravida@at.com</Email>
+    <Company>Duis Cursus Ltd</Company>
+    <Id>52CAD16F-E1F7-36A0-CB66-8180B1C45A48</Id>
+    <Location>-32.55557, -19.61296</Location>
+  </record>
+  <record>
+    <Test>Philip</Test>
+    <Phone>1-786-171-6833</Phone>
+    <Address>9892 Lobortis Street</Address>
+    <City>Göteborg</City>
+    <State>O</State>
+    <Country>Kiribati</Country>
+    <Email>et@sociisnatoquepenatibus.ca</Email>
+    <Company>Dui Fusce Diam LLC</Company>
+    <Id>BCD27B74-45D0-0409-8DB4-5EEC394C1300</Id>
+    <Location>-54.34379, 155.5195</Location>
+  </record>
+  <record>
+    <Test>Anthony</Test>
+    <Phone>1-251-479-7984</Phone>
+    <Address>5333 Nulla. Rd.</Address>
+    <City>Melipilla</City>
+    <State>RM</State>
+    <Country>Sao Tome and Principe</Country>
+    <Email>Aliquam@augueac.edu</Email>
+    <Company>Curabitur Sed Inc.</Company>
+    <Id>19642087-D0C3-A1F2-9707-6291BDF27D56</Id>
+    <Location>-30.00586, 2.52299</Location>
+  </record>
+  <record>
+    <Test>Jason</Test>
+    <Phone>1-569-120-1063</Phone>
+    <Address>966-9176 Auctor Street</Address>
+    <City>Clovenfords</City>
+    <State>Selkirkshire</State>
+    <Country>Malta</Country>
+    <Email>commodo.tincidunt.nibh@non.net</Email>
+    <Company>Amet Ultricies Incorporated</Company>
+    <Id>A740EC62-374B-25B0-3632-1E13865CC636</Id>
+    <Location>65.50191, 164.10451</Location>
+  </record>
+  <record>
+    <Test>Ferdinand</Test>
+    <Phone>1-673-825-5078</Phone>
+    <Address>P.O. Box 762, 5338 Nibh Rd.</Address>
+    <City>St. Catharines</City>
+    <State>Ontario</State>
+    <Country>Nigeria</Country>
+    <Email>nulla.Donec@magna.co.uk</Email>
+    <Company>Hendrerit Associates</Company>
+    <Id>BF2D3882-FE89-845A-E7EC-8BB0430F2573</Id>
+    <Location>4.37167, -163.39859</Location>
+  </record>
+  <record>
+    <Test>Bevis</Test>
+    <Phone>1-177-416-4496</Phone>
+    <Address>9251 Integer Ave</Address>
+    <City>Champigny-sur-Marne</City>
+    <State>IL</State>
+    <Country>New Zealand</Country>
+    <Email>iaculis.aliquet.diam@anteMaecenas.ca</Email>
+    <Company>Varius Nam Corporation</Company>
+    <Id>F40CFB95-BB7D-2D72-180B-87C860D01397</Id>
+    <Location>76.4493, 160.79455</Location>
+  </record>
+  <record>
+    <Test>Arthur</Test>
+    <Phone>1-724-580-4172</Phone>
+    <Address>8331 Fermentum St.</Address>
+    <City>Boo</City>
+    <State>Stockholms län</State>
+    <Country>Myanmar</Country>
+    <Email>et.tristique@euarcuMorbi.co.uk</Email>
+    <Company>Penatibus Et Magnis Incorporated</Company>
+    <Id>DD2E1F93-4179-792F-FB2F-2C37B6196A20</Id>
+    <Location>47.27339, 60.23051</Location>
+  </record>
+  <record>
+    <Test>Steven</Test>
+    <Phone>1-239-316-4494</Phone>
+    <Address>Ap #598-1327 Pretium St.</Address>
+    <City>Birecik</City>
+    <State>Şanlıurfa</State>
+    <Country>Luxembourg</Country>
+    <Email>hendrerit@Nuncquis.org</Email>
+    <Company>Cum Corp.</Company>
+    <Id>528DB1FE-FA2F-EB2B-17A8-7E0D12F3CE2C</Id>
+    <Location>-22.31193, -62.91764</Location>
+  </record>
+  <record>
+    <Test>Levi</Test>
+    <Phone>1-282-730-5088</Phone>
+    <Address>Ap #379-2871 Adipiscing Rd.</Address>
+    <City>Fort Saskatchewan</City>
+    <State>AB</State>
+    <Country>Luxembourg</Country>
+    <Email>augue.Sed@convallis.edu</Email>
+    <Company>Sollicitudin LLC</Company>
+    <Id>5506399D-5504-BD38-F05B-CA9FA401D9F6</Id>
+    <Location>-40.54278, 161.68704</Location>
+  </record>
+  <record>
+    <Test>Channing</Test>
+    <Phone>1-353-382-4419</Phone>
+    <Address>8301 Cursus Avenue</Address>
+    <City>Nijkerk</City>
+    <State>Gelderland</State>
+    <Country>Russian Federation</Country>
+    <Email>vel.vulputate.eu@Aeneanegetmetus.edu</Email>
+    <Company>Mauris Molestie Pharetra Inc.</Company>
+    <Id>29C86344-37D8-1E31-CD2D-3C6A50D8A3AA</Id>
+    <Location>21.82752, -166.84984</Location>
+  </record>
+  <record>
+    <Test>Nasim</Test>
+    <Phone>1-982-911-0201</Phone>
+    <Address>P.O. Box 800, 6457 Tempor Ave</Address>
+    <City>Zaanstad</City>
+    <State>N.</State>
+    <Country>Burundi</Country>
+    <Email>Mauris.vel.turpis@consequatauctor.com</Email>
+    <Company>Urna Nec Luctus Institute</Company>
+    <Id>8D89BD00-0982-24D3-86D9-7247526B9446</Id>
+    <Location>-77.85501, -92.23963</Location>
+  </record>
+  <record>
+    <Test>Blaze</Test>
+    <Phone>1-653-943-6639</Phone>
+    <Address>P.O. Box 578, 8585 Conubia Street</Address>
+    <City>Butte</City>
+    <State>Montana</State>
+    <Country>Seychelles</Country>
+    <Email>gravida.Aliquam.tincidunt@pharetra.net</Email>
+    <Company>Justo Faucibus Ltd</Company>
+    <Id>6CFD2EFA-AFBD-F4B9-1F20-128B552EC65F</Id>
+    <Location>-24.37248, 82.15544</Location>
+  </record>
+  <record>
+    <Test>Robert</Test>
+    <Phone>1-826-142-0863</Phone>
+    <Address>P.O. Box 760, 4059 Tristique St.</Address>
+    <City>Marcq-en-Baroeul</City>
+    <State>Nord-Pas-de-Calais</State>
+    <Country>Syria</Country>
+    <Email>quis.accumsan@eu.net</Email>
+    <Company>Ut Quam Limited</Company>
+    <Id>CC0D55F5-3116-AED6-FC92-58E737F60399</Id>
+    <Location>28.52352, -156.29285</Location>
+  </record>
+  <record>
+    <Test>Myles</Test>
+    <Phone>1-976-377-6817</Phone>
+    <Address>P.O. Box 507, 5210 Non, St.</Address>
+    <City>Paignton</City>
+    <State>Devon</State>
+    <Country>Martinique</Country>
+    <Email>turpis.Nulla@orci.net</Email>
+    <Company>Enim Mi Inc.</Company>
+    <Id>6516D7DC-7662-2A5A-B785-DBA173E1C7A3</Id>
+    <Location>-86.01305, 29.09127</Location>
+  </record>
+  <record>
+    <Test>Craig</Test>
+    <Phone>1-120-826-7926</Phone>
+    <Address>988-4473 Gravida Ave</Address>
+    <City>Cork</City>
+    <State>M</State>
+    <Country>Anguilla</Country>
+    <Email>ultrices@neccursus.ca</Email>
+    <Company>Suspendisse PC</Company>
+    <Id>68D2DB13-EC44-F298-0149-0B42CCFA7183</Id>
+    <Location>-67.20445, -72.28217</Location>
+  </record>
+  <record>
+    <Test>Gray</Test>
+    <Phone>1-163-570-1770</Phone>
+    <Address>P.O. Box 394, 9269 Dis St.</Address>
+    <City>Izmir</City>
+    <State>İzmir</State>
+    <Country>Singapore</Country>
+    <Email>tincidunt.vehicula@tempordiam.net</Email>
+    <Company>Fermentum Company</Company>
+    <Id>FE414323-8093-86DA-77E5-F78692942336</Id>
+    <Location>-24.65255, 20.65139</Location>
+  </record>
+  <record>
+    <Test>Beck</Test>
+    <Phone>1-874-314-8270</Phone>
+    <Address>Ap #864-3486 Odio Ave</Address>
+    <City>Tiltil</City>
+    <State>RM</State>
+    <Country>Malta</Country>
+    <Email>Sed@Aliquamtincidunt.co.uk</Email>
+    <Company>Vulputate Nisi Sem Foundation</Company>
+    <Id>661EDEB4-986C-2F8A-C9A3-2CDC389376FD</Id>
+    <Location>-88.88899, -75.1028</Location>
+  </record>
+</records>

--- a/AnySerializer/AnySerializer.Tests/TestHelper.cs
+++ b/AnySerializer/AnySerializer.Tests/TestHelper.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+
+namespace AnySerializer.Tests
+{
+    public static class TestHelper
+    {
+        public static string GetResourceFileText(string filename)
+        {
+            var result = string.Empty;
+            var assembly = Assembly.GetExecutingAssembly();
+
+            using (var stream =
+                assembly.GetManifestResourceStream($"{assembly.GetName().Name}.{filename}"))
+            {
+                using (var sr = new StreamReader(stream))
+                {
+                    result = sr.ReadToEnd();
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/AnySerializer/AnySerializer.Tests/TestObjects/RecursiveStructObject.cs
+++ b/AnySerializer/AnySerializer.Tests/TestObjects/RecursiveStructObject.cs
@@ -1,0 +1,18 @@
+﻿using System.Runtime.InteropServices;
+
+namespace AnySerializer.Tests.TestObjects
+{
+    [StructLayout(LayoutKind.Auto)]
+    public struct RecursiveStructObject
+    {
+        public int Id { get; }
+        // static members should not be recursed in structs
+        public static readonly RecursiveStructObject MinId = new RecursiveStructObject(0);
+        public static readonly RecursiveStructObject MaxId = new RecursiveStructObject(100);
+
+        public RecursiveStructObject(int id)
+        {
+            Id = id;
+        }
+    }
+}

--- a/AnySerializer/AnySerializer.Tests/TestObjects/StructObject.cs
+++ b/AnySerializer/AnySerializer.Tests/TestObjects/StructObject.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace AnySerializer.Tests.TestObjects
+{
+    [StructLayout(LayoutKind.Auto)]
+    public struct StructObject
+    {
+        public int Id { get; }
+        public int Value { get; }
+
+        public StructObject(int id, int value)
+        {
+            Id = id;
+            Value = value;
+        }
+    }
+}

--- a/AnySerializer/AnySerializer.Tests/XmlSerializationTests.cs
+++ b/AnySerializer/AnySerializer.Tests/XmlSerializationTests.cs
@@ -1,0 +1,24 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml.Linq;
+
+namespace AnySerializer.Tests
+{
+    [TestFixture]
+    public class XmlSerializationTests
+    {
+        [Test]
+        public void ShouldSerialize_Xml()
+        {
+            
+            var test = XDocument.Load(@".\TestData\basic.xml");
+            var provider = new SerializerProvider();
+            var bytes = provider.Serialize(test);
+            var deserializedTest = provider.Deserialize<XDocument>(bytes);
+
+            Assert.AreEqual(test, deserializedTest);
+        }
+    }
+}

--- a/AnySerializer/AnySerializer.Tests/XmlSerializationTests.cs
+++ b/AnySerializer/AnySerializer.Tests/XmlSerializationTests.cs
@@ -7,14 +7,25 @@ namespace AnySerializer.Tests
     public class XmlSerializationTests
     {
         [Test]
-        public void ShouldSerialize_Xml()
+        public void ShouldSerialize_Basic_Xml()
         {
             var test = XDocument.Load(@".\TestData\basic.xml");
             var provider = new SerializerProvider();
             var bytes = provider.Serialize(test, SerializerOptions.EmbedTypes);
             var deserializedTest = provider.Deserialize<XDocument>(bytes);
 
-            Assert.AreEqual(test, deserializedTest);
+            Assert.AreEqual(test.ToString(), deserializedTest.ToString());
+        }
+
+        [Test]
+        public void ShouldSerialize_Complex_Xml()
+        {
+            var test = XDocument.Load(@".\TestData\complex.xml");
+            var provider = new SerializerProvider();
+            var bytes = provider.Serialize(test, SerializerOptions.EmbedTypes);
+            var deserializedTest = provider.Deserialize<XDocument>(bytes);
+
+            Assert.AreEqual(test.ToString(), deserializedTest.ToString());
         }
     }
 }

--- a/AnySerializer/AnySerializer.Tests/XmlSerializationTests.cs
+++ b/AnySerializer/AnySerializer.Tests/XmlSerializationTests.cs
@@ -9,7 +9,7 @@ namespace AnySerializer.Tests
         [Test]
         public void ShouldSerialize_Basic_Xml()
         {
-            var test = XDocument.Load(@".\TestData\basic.xml");
+            var test = XDocument.Parse(TestHelper.GetResourceFileText(@"TestData.basic.xml"));
             var provider = new SerializerProvider();
             var bytes = provider.Serialize(test, SerializerOptions.EmbedTypes);
             var deserializedTest = provider.Deserialize<XDocument>(bytes);
@@ -20,7 +20,7 @@ namespace AnySerializer.Tests
         [Test]
         public void ShouldSerialize_Complex_Xml()
         {
-            var test = XDocument.Load(@".\TestData\complex.xml");
+            var test = XDocument.Parse(TestHelper.GetResourceFileText(@"TestData.complex.xml"));
             var provider = new SerializerProvider();
             var bytes = provider.Serialize(test, SerializerOptions.EmbedTypes);
             var deserializedTest = provider.Deserialize<XDocument>(bytes);

--- a/AnySerializer/AnySerializer.Tests/XmlSerializationTests.cs
+++ b/AnySerializer/AnySerializer.Tests/XmlSerializationTests.cs
@@ -12,10 +12,9 @@ namespace AnySerializer.Tests
         [Test]
         public void ShouldSerialize_Xml()
         {
-            
             var test = XDocument.Load(@".\TestData\basic.xml");
             var provider = new SerializerProvider();
-            var bytes = provider.Serialize(test);
+            var bytes = provider.Serialize(test, SerializerOptions.EmbedTypes);
             var deserializedTest = provider.Deserialize<XDocument>(bytes);
 
             Assert.AreEqual(test, deserializedTest);

--- a/AnySerializer/AnySerializer.Tests/XmlSerializationTests.cs
+++ b/AnySerializer/AnySerializer.Tests/XmlSerializationTests.cs
@@ -1,7 +1,4 @@
 ﻿using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Xml.Linq;
 
 namespace AnySerializer.Tests

--- a/AnySerializer/AnySerializer/AnySerializer.csproj
+++ b/AnySerializer/AnySerializer/AnySerializer.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="lz4net" Version="1.0.15.93" />
-    <PackageReference Include="TypeSupport" Version="1.0.12" />
+    <PackageReference Include="TypeSupport" Version="1.0.44" />
   </ItemGroup>
 
 </Project>

--- a/AnySerializer/AnySerializer/AnySerializer.csproj
+++ b/AnySerializer/AnySerializer/AnySerializer.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="lz4net" Version="1.0.15.93" />
-    <PackageReference Include="TypeSupport" Version="1.0.44" />
+    <PackageReference Include="TypeSupport" Version="1.0.45" />
   </ItemGroup>
 
 </Project>

--- a/AnySerializer/AnySerializer/CustomSerializers/XDocumentSerializer.cs
+++ b/AnySerializer/AnySerializer/CustomSerializers/XDocumentSerializer.cs
@@ -1,0 +1,31 @@
+﻿using System.Xml.Linq;
+
+namespace AnySerializer.CustomSerializers
+{
+    public class XDocumentSerializer : ICustomSerializer<XDocument>
+    {
+        public short DataSize => sizeof(long);
+
+        public XDocument Deserialize(byte[] bytes, uint length)
+        {
+            var xmlString = System.Text.ASCIIEncoding.Unicode.GetString(bytes);
+
+            return XDocument.Parse(xmlString, LoadOptions.PreserveWhitespace);
+        }
+
+        public byte[] Serialize(XDocument type)
+        {
+            return System.Text.ASCIIEncoding.Unicode.GetBytes(type.ToString(SaveOptions.DisableFormatting));
+        }
+
+        public byte[] Serialize(object type)
+        {
+            return Serialize((XDocument)type);
+        }
+
+        object ICustomSerializer.Deserialize(byte[] bytes, uint length)
+        {
+            return Deserialize(bytes, length);
+        }
+    }
+}

--- a/AnySerializer/AnySerializer/TypeDescriptors.cs
+++ b/AnySerializer/AnySerializer/TypeDescriptors.cs
@@ -33,14 +33,16 @@ namespace AnySerializer
         /// <param name="type"></param>
         public ushort AddKnownType(ExtendedType type)
         {
-            var existingType = Types.FirstOrDefault(x => x.FullName.Equals(type.Type.FullName));
+            var fullName = string.Empty;
+            if (type.ConcreteType != null && (type.IsInterface || type.IsAnonymous || type.Type == typeof(object)))
+                fullName = type.ConcreteType.AssemblyQualifiedName;
+            else
+                fullName = type.Type.AssemblyQualifiedName;
+            var existingType = Types.FirstOrDefault(x => x.FullName.Equals(fullName));
             if (existingType == null)
             {
                 // add a new type to the map
                 var typeId = _currentTypeId;
-                var fullName = type.Type.AssemblyQualifiedName;
-                if (type.IsInterface)
-                    fullName = type.ConcreteType.AssemblyQualifiedName;
                 Types.Add(new TypeDescriptor(typeId, fullName));
                 _currentTypeId++;
                 return typeId;

--- a/AnySerializer/AnySerializer/TypeDescriptors.cs
+++ b/AnySerializer/AnySerializer/TypeDescriptors.cs
@@ -34,7 +34,7 @@ namespace AnySerializer
         public ushort AddKnownType(ExtendedType type)
         {
             var fullName = string.Empty;
-            if (type.ConcreteType != null && (type.IsInterface || type.IsAnonymous || type.Type == typeof(object)))
+            if (!type.IsConcreteType && type.ConcreteType != null)
                 fullName = type.ConcreteType.AssemblyQualifiedName;
             else
                 fullName = type.Type.AssemblyQualifiedName;

--- a/AnySerializer/AnySerializer/TypeManagement.cs
+++ b/AnySerializer/AnySerializer/TypeManagement.cs
@@ -23,6 +23,7 @@ namespace AnySerializer
                         { typeof(string), TypeId.String },
                         { typeof(char), TypeId.Char },
                         { typeof(Enum), TypeId.Enum },
+                        { typeof(IntPtr), TypeId.IntPtr },
                         { typeof(object), TypeId.Object },
                         { typeof(Guid), TypeId.Guid },
                         { typeof(DateTime), TypeId.DateTime },
@@ -64,6 +65,8 @@ namespace AnySerializer
             Point       = 19,
             Tuple       = 20,
             KeyValuePair= 21,
+            Struct = 22,
+            IntPtr = 23,
 
             // special bit to indicate a type map is stored for this type (concrete types for interfaces, anonymous types)
             TypeMapped = 32,

--- a/AnySerializer/AnySerializer/TypeReader.cs
+++ b/AnySerializer/AnySerializer/TypeReader.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Xml.Linq;
 using TypeSupport;
 using TypeSupport.Extensions;
 using static AnySerializer.TypeManagement;
@@ -62,7 +63,8 @@ namespace AnySerializer
             _customSerializers = new Dictionary<Type, Lazy<ICustomSerializer>>()
             {
                 { typeof(Point), new Lazy<ICustomSerializer>(() => new PointSerializer()) },
-                { typeof(Enum), new Lazy<ICustomSerializer>(() => new EnumSerializer()) }
+                { typeof(Enum), new Lazy<ICustomSerializer>(() => new EnumSerializer()) },
+                { typeof(XDocument), new Lazy<ICustomSerializer>(() => new XDocumentSerializer()) },
             };
 
         }
@@ -215,35 +217,47 @@ namespace AnySerializer
                 throw new DataFormatException($"[{path}] {ex.Message}", ex);
             }
 
-            switch (objectTypeId)
+            // custom types support
+            var objectDataLength = dataLength;
+            var @switch = new Dictionary<Type, Func<object>>
+                {
+                    { typeof(XDocument), () => { return ReadValueType(reader, objectDataLength, typeSupport, currentDepth, path); } },
+                };
+
+            if (@switch.ContainsKey(typeSupport.Type))
+                newObj = @switch[typeSupport.Type]();
+            else
             {
-                case TypeId.Object:
-                    newObj = ReadObjectType(newObj, reader, dataLength, typeSupport, currentDepth, path, typeDescriptor);
-                    break;
-                case TypeId.Struct:
-                    newObj = ReadStructType(newObj, reader, dataLength, typeSupport, currentDepth, path, typeDescriptor);
-                    break;
-                case TypeId.Array:
-                    newObj = ReadArrayType(newObj, reader, dataLength, typeSupport, currentDepth, path, typeDescriptor);
-                    break;
-                case TypeId.IDictionary:
-                    newObj = ReadDictionaryType(newObj, reader, dataLength, typeSupport, currentDepth, path, typeDescriptor);
-                    break;
-                case TypeId.IEnumerable:
-                    newObj = ReadEnumerableType(newObj, reader, dataLength, typeSupport, currentDepth, path, typeDescriptor);
-                    break;
-                case TypeId.KeyValuePair:
-                    newObj = ReadKeyValueType(newObj, reader, dataLength, typeSupport, currentDepth, path, typeDescriptor);
-                    break;
-                case TypeId.Enum:
-                    newObj = ReadValueType(reader, dataLength, new ExtendedType(typeof(Enum)), currentDepth, path);
-                    break;
-                case TypeId.Tuple:
-                    newObj = ReadTupleType(newObj, reader, dataLength, typeSupport, currentDepth, path, typeDescriptor);
-                    break;
-                default:
-                    newObj = ReadValueType(reader, dataLength, typeSupport, currentDepth, path);
-                    break;
+                switch (objectTypeId)
+                {
+                    case TypeId.Object:
+                        newObj = ReadObjectType(newObj, reader, dataLength, typeSupport, currentDepth, path, typeDescriptor);
+                        break;
+                    case TypeId.Struct:
+                        newObj = ReadStructType(newObj, reader, dataLength, typeSupport, currentDepth, path, typeDescriptor);
+                        break;
+                    case TypeId.Array:
+                        newObj = ReadArrayType(newObj, reader, dataLength, typeSupport, currentDepth, path, typeDescriptor);
+                        break;
+                    case TypeId.IDictionary:
+                        newObj = ReadDictionaryType(newObj, reader, dataLength, typeSupport, currentDepth, path, typeDescriptor);
+                        break;
+                    case TypeId.IEnumerable:
+                        newObj = ReadEnumerableType(newObj, reader, dataLength, typeSupport, currentDepth, path, typeDescriptor);
+                        break;
+                    case TypeId.KeyValuePair:
+                        newObj = ReadKeyValueType(newObj, reader, dataLength, typeSupport, currentDepth, path, typeDescriptor);
+                        break;
+                    case TypeId.Enum:
+                        newObj = ReadValueType(reader, dataLength, new ExtendedType(typeof(Enum)), currentDepth, path);
+                        break;
+                    case TypeId.Tuple:
+                        newObj = ReadTupleType(newObj, reader, dataLength, typeSupport, currentDepth, path, typeDescriptor);
+                        break;
+                    default:
+                        newObj = ReadValueType(reader, dataLength, typeSupport, currentDepth, path);
+                        break;
+                }
             }
 
             // store the object reference id in the object reference map
@@ -272,6 +286,10 @@ namespace AnySerializer
                 { typeof(string), () => reader.ReadString() },
                 { typeof(Enum), () => {
                     var result = _customSerializers[typeof(Enum)].Value.Deserialize(reader.ReadBytes((int)dataLength), dataLength);
+                    return result;
+                }},
+                { typeof(XDocument), () => {
+                    var result = _customSerializers[typeof(XDocument)].Value.Deserialize(reader.ReadBytes((int)dataLength), dataLength);
                     return result;
                 }},
                 { typeof(char), () => reader.ReadChar() },

--- a/AnySerializer/AnySerializer/TypeReader.cs
+++ b/AnySerializer/AnySerializer/TypeReader.cs
@@ -205,8 +205,7 @@ namespace AnySerializer
                 if (!string.IsNullOrEmpty(typeDescriptor?.FullName))
                 {
                     newObj = objectFactory.CreateEmptyObject(typeDescriptor.FullName, _typeRegistry);
-                    if(newObj != null)
-                        typeSupport = newObj.GetType().GetExtendedType();
+                    typeSupport = Type.GetType(typeDescriptor.FullName).GetExtendedType();
                 }
                 else
                     newObj = objectFactory.CreateEmptyObject(typeSupport.Type, _typeRegistry);

--- a/AnySerializer/AnySerializer/TypeUtil.cs
+++ b/AnySerializer/AnySerializer/TypeUtil.cs
@@ -178,6 +178,9 @@ namespace AnySerializer
             if (typeSupport.IsEnum)
                 return TypeId.Enum;
 
+            if (typeSupport.IsStruct)
+                return TypeId.Struct;
+
             if (typeSupport.IsGeneric && typeSupport.Type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
                 return TypeManagement.TypeMapping[typeof(KeyValuePair<,>)];
 
@@ -213,10 +216,13 @@ namespace AnySerializer
             if (typeof(IEnumerable).IsAssignableFrom(typeSupport.NullableBaseType))
                 return TypeManagement.TypeMapping[typeof(IEnumerable)];
 
+            if (typeSupport.Type == typeof(IntPtr))
+                return TypeManagement.TypeMapping[typeof(long)];
+
             if (typeSupport.IsValueType || typeSupport.IsPrimitive)
                 throw new InvalidOperationException($"Unsupported type: {typeSupport.NullableBaseType.FullName}");
 
-            return TypeManagement.TypeMapping[typeof(object)];
+            return TypeId.Object;
         }
 
         /// <summary>
@@ -228,7 +234,10 @@ namespace AnySerializer
         {
             if (!TypeManagement.TypeMapping.Values.Contains(type))
                 throw new InvalidOperationException($"Invalid type specified: {(int)type}");
-            var typeSupport = new ExtendedType(TypeManagement.TypeMapping.Where(x => x.Value == type).Select(x => x.Key).FirstOrDefault());
+            var typeSupport = new ExtendedType(TypeManagement.TypeMapping
+                .Where(x => x.Value == type)
+                .Select(x => x.Key)
+                .FirstOrDefault());
             return typeSupport;
         }
 

--- a/AnySerializer/AnySerializer/TypeUtil.cs
+++ b/AnySerializer/AnySerializer/TypeUtil.cs
@@ -178,9 +178,6 @@ namespace AnySerializer
             if (typeSupport.IsEnum)
                 return TypeId.Enum;
 
-            if (typeSupport.IsStruct)
-                return TypeId.Struct;
-
             if (typeSupport.IsGeneric && typeSupport.Type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
                 return TypeManagement.TypeMapping[typeof(KeyValuePair<,>)];
 
@@ -218,6 +215,9 @@ namespace AnySerializer
 
             if (typeSupport.Type == typeof(IntPtr))
                 return TypeManagement.TypeMapping[typeof(long)];
+
+            if (typeSupport.IsStruct && typeSupport.Type != typeof(decimal))
+                return TypeId.Struct;
 
             if (typeSupport.IsValueType || typeSupport.IsPrimitive)
                 throw new InvalidOperationException($"Unsupported type: {typeSupport.NullableBaseType.FullName}");


### PR DESCRIPTION
Fixes #8 Adds serialization support to XDocument objects. They are rather complex because of the node structure. The solution ended up being just serialize it as string data, as I couldn't get the tree traversal to work and will require additional effort to figure out.