### PR TITLE
Static analysis updates and compression update

### DIFF
--- a/AnySerializer/AnySerializer.Tests/AnySerializer.Tests.csproj
+++ b/AnySerializer/AnySerializer.Tests/AnySerializer.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net40;net45;net46;net461;net462;net47</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net45;net46;net461;net462;net47</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 

--- a/AnySerializer/AnySerializer.Tests/CompressDeserializationTests.cs
+++ b/AnySerializer/AnySerializer.Tests/CompressDeserializationTests.cs
@@ -6,6 +6,7 @@ namespace AnySerializer.Tests
     [TestFixture]
     public class CompressDeserializationTests
     {
+#if FEATURE_COMPRESSION
         [Test]
         public void ShouldDeserialize_Compress_Bool()
         {
@@ -43,5 +44,6 @@ namespace AnySerializer.Tests
 
             Assert.AreEqual(test, testDeserialized);
         }
+#endif
     }
 }

--- a/AnySerializer/AnySerializer.Tests/SizeTests.cs
+++ b/AnySerializer/AnySerializer.Tests/SizeTests.cs
@@ -102,6 +102,7 @@ namespace AnySerializer.Tests
             Assert.DoesNotThrow(() => provider.Serialize(test));
         }
 
+#if FEATURE_COMPRESSION
         [Test]
         public void Should_Compress_BeSmaller_OnLargeObjects()
         {
@@ -124,7 +125,7 @@ namespace AnySerializer.Tests
             var restored = provider.Deserialize<List<string>>(compressedBytes);
             Assert.NotNull(restored);
 
-            Assert.Greater(compressionRatio, 30.0); // we expect a large gain here
+            Assert.Greater(compressionRatio, 25.0); // we expect a large gain here
             Assert.Greater(uncompressedBytes.Length, compressedBytes.Length);
         }
 
@@ -167,5 +168,6 @@ namespace AnySerializer.Tests
             Assert.GreaterOrEqual(compressionRatio, 1.0); // we expect a small gain here
             Assert.Greater(uncompressedBytes.Length, compressedBytes.Length);
         }
+#endif
     }
 }

--- a/AnySerializer/AnySerializer.Tests/TestObjects/XDocumentContainer.cs
+++ b/AnySerializer/AnySerializer.Tests/TestObjects/XDocumentContainer.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Xml.Linq;
+
+namespace AnySerializer.Tests.TestObjects
+{
+    public class XDocumentContainer : IEquatable<XDocumentContainer>
+    {
+        public int Id { get; }
+        public XDocument Document { get; }
+        public string DocumentName { get; }
+        public XDocumentContainer(int id, string documentName, XDocument document)
+        {
+            Id = id;
+            DocumentName = documentName;
+            Document = document;
+        }
+
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+                return false;
+            if (obj.GetType() != typeof(XDocumentContainer))
+                return false;
+            return Equals((XDocumentContainer)obj);
+        }
+
+        public bool Equals(XDocumentContainer other)
+        {
+            if (other == null)
+                return false;
+            return Id == other.Id
+                && DocumentName == other.DocumentName
+                && Document.ToString() == other.Document.ToString();
+        }
+    }
+}

--- a/AnySerializer/AnySerializer.Tests/TypeDescriptorTests.cs
+++ b/AnySerializer/AnySerializer.Tests/TypeDescriptorTests.cs
@@ -12,7 +12,11 @@ namespace AnySerializer.Tests
         {
             var bytes = Serialize();
             Assert.Greater(bytes.Length, 0);
+#if FEATURE_COMPRESSION
             Assert.Less(bytes.Length, 250);
+#else
+            Assert.Less(bytes.Length, 800);
+#endif
         }
 
         [Test]

--- a/AnySerializer/AnySerializer.Tests/ValidationTests.cs
+++ b/AnySerializer/AnySerializer.Tests/ValidationTests.cs
@@ -40,6 +40,7 @@ namespace AnySerializer.Tests
             Assert.IsTrue(isValid);
         }
 
+#if FEATURE_COMPRESSION
         [Test]
         public void ShouldValidate_Compressed_BasicObject()
         {
@@ -55,6 +56,7 @@ namespace AnySerializer.Tests
 
             Assert.IsTrue(isValid);
         }
+#endif
 
         [Test]
         public void ShouldValidate_BasicObjectWithEmptyEmbeddedTypeDescriptors()

--- a/AnySerializer/AnySerializer.Tests/XmlSerializationTests.cs
+++ b/AnySerializer/AnySerializer.Tests/XmlSerializationTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using AnySerializer.Tests.TestObjects;
+using NUnit.Framework;
 using System.Xml.Linq;
 
 namespace AnySerializer.Tests
@@ -11,7 +12,7 @@ namespace AnySerializer.Tests
         {
             var test = XDocument.Parse(TestHelper.GetResourceFileText(@"TestData.basic.xml"));
             var provider = new SerializerProvider();
-            var bytes = provider.Serialize(test, SerializerOptions.EmbedTypes);
+            var bytes = provider.Serialize(test);
             var deserializedTest = provider.Deserialize<XDocument>(bytes);
 
             Assert.AreEqual(test.ToString(), deserializedTest.ToString());
@@ -22,10 +23,21 @@ namespace AnySerializer.Tests
         {
             var test = XDocument.Parse(TestHelper.GetResourceFileText(@"TestData.complex.xml"));
             var provider = new SerializerProvider();
-            var bytes = provider.Serialize(test, SerializerOptions.EmbedTypes);
+            var bytes = provider.Serialize(test);
             var deserializedTest = provider.Deserialize<XDocument>(bytes);
 
             Assert.AreEqual(test.ToString(), deserializedTest.ToString());
+        }
+
+        [Test]
+        public void ShouldSerialize_Basic_XmlContainer()
+        {
+            var test = new XDocumentContainer(1, "Test", XDocument.Parse(TestHelper.GetResourceFileText(@"TestData.basic.xml")));
+            var provider = new SerializerProvider();
+            var bytes = provider.Serialize(test);
+            var deserializedTest = provider.Deserialize<XDocumentContainer>(bytes);
+
+            Assert.AreEqual(test, deserializedTest);
         }
     }
 }

--- a/AnySerializer/AnySerializer/AnySerializer.csproj
+++ b/AnySerializer/AnySerializer/AnySerializer.csproj
@@ -9,9 +9,9 @@
     <PackageProjectUrl>https://github.com/replaysMike/AnySerializer</PackageProjectUrl>
     <RepositoryUrl>https://github.com/replaysMike/AnySerializer</RepositoryUrl>
     <PackageTags>serialize deserialize object serialization deserialization refactor software michael brown</PackageTags>
-    <AssemblyVersion>1.0.7.0</AssemblyVersion>
-    <FileVersion>1.0.7.0</FileVersion>
-    <Version>1.0.7</Version>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/AnySerializer/AnySerializer/AnySerializer.csproj
+++ b/AnySerializer/AnySerializer/AnySerializer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40;net45;net46;net461;net462;net47</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;net46;net461;net462;net47</TargetFrameworks>
     <Authors>Michael Brown</Authors>
     <Company>Refactor Software</Company>
     <Description>Serialize and deserialize any object without decoration/attributes.</Description>

--- a/AnySerializer/AnySerializer/AnySerializer.csproj
+++ b/AnySerializer/AnySerializer/AnySerializer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45;net46;net461;net462;net47</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0;net46;net461;net462;net47</TargetFrameworks>
     <Authors>Michael Brown</Authors>
     <Company>Refactor Software</Company>
     <Description>Serialize and deserialize any object without decoration/attributes.</Description>
@@ -18,17 +18,29 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0' OR '$(TargetFramework)'=='net45' OR '$(TargetFramework)'=='net46' OR '$(TargetFramework)'=='net461' OR '$(TargetFramework)'=='net462'">
+  <PropertyGroup Condition="'$(TargetFramework)'=='net45'">
     <DefineConstants>FEATURE_CUSTOM_ATTRIBUTES;FEATURE_CUSTOM_TYPEINFO;FEATURE_GETMETHOD;FEATURE_SETVALUE;FEATURE_TASK;FEATURE_ASSEMBLYBUILDER</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0' OR '$(TargetFramework)'=='net47'">
-    <DefineConstants>FEATURE_CUSTOM_VALUETUPLE;FEATURE_CUSTOM_ATTRIBUTES;FEATURE_CUSTOM_TYPEINFO;FEATURE_GETMETHOD;FEATURE_SETVALUE;FEATURE_TASK;FEATURE_ASSEMBLYBUILDER</DefineConstants>
+  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0' OR '$(TargetFramework)'=='net46' OR '$(TargetFramework)'=='net461' OR '$(TargetFramework)'=='net462'">
+    <DefineConstants>FEATURE_CUSTOM_ATTRIBUTES;FEATURE_CUSTOM_TYPEINFO;FEATURE_GETMETHOD;FEATURE_SETVALUE;FEATURE_TASK;FEATURE_ASSEMBLYBUILDER;FEATURE_COMPRESSION</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net47'">
+    <DefineConstants>FEATURE_CUSTOM_VALUETUPLE;FEATURE_CUSTOM_ATTRIBUTES;FEATURE_CUSTOM_TYPEINFO;FEATURE_GETMETHOD;FEATURE_SETVALUE;FEATURE_TASK;FEATURE_ASSEMBLYBUILDER;FEATURE_COMPRESSION</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="lz4net" Version="1.0.15.93" />
     <PackageReference Include="TypeSupport" Version="1.0.45" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' OR '$(TargetFramework)'=='net46' OR '$(TargetFramework)'=='net461' OR '$(TargetFramework)'=='net462' OR '$(TargetFramework)'=='net47'">
+    <PackageReference Include="K4os.Compression.LZ4">
+      <Version>1.1.1</Version>
+    </PackageReference>
+    <PackageReference Include="K4os.Compression.LZ4.Streams">
+      <Version>1.1.1</Version>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/AnySerializer/AnySerializer/Constants.cs
+++ b/AnySerializer/AnySerializer/Constants.cs
@@ -5,30 +5,30 @@
         /// <summary>
         /// The size of the data settings header value (byte-0)
         /// </summary>
-        public const int DataSettingsSize = 1;
+        public static readonly uint DataSettingsSize = 1;
         /// <summary>
         /// The size of the object type header
         /// </summary>
-        public const int TypeHeaderSize = 1;
+        public static readonly uint TypeHeaderSize = 1;
         /// <summary>
         /// The size of the length header
         /// </summary>
-        public const int LengthHeaderSize = sizeof(uint);
+        public static readonly uint LengthHeaderSize = sizeof(uint);
         /// <summary>
         /// The size of the length header in compact mode
         /// </summary>
-        public const int CompactLengthHeaderSize = sizeof(ushort);
+        public static readonly uint CompactLengthHeaderSize = sizeof(ushort);
         /// <summary>
         /// The size of the object reference id
         /// </summary>
-        public const int ObjectReferenceIdSize = sizeof(ushort);
+        public static readonly uint ObjectReferenceIdSize = sizeof(ushort);
         /// <summary>
         /// The size of the object type id (Type Descriptor)
         /// </summary>
-        public const int ObjectTypeDescriptorId = sizeof(ushort);
+        public static readonly uint ObjectTypeDescriptorId = sizeof(ushort);
         /// <summary>
         /// The maximum recursion depth to use, by default.
         /// </summary>
-        public const int DefaultMaxDepth = 32;
+        public static readonly uint DefaultMaxDepth = 32;
     }
 }

--- a/AnySerializer/AnySerializer/CustomSerializers/EnumSerializer.cs
+++ b/AnySerializer/AnySerializer/CustomSerializers/EnumSerializer.cs
@@ -19,9 +19,9 @@ namespace AnySerializer.CustomSerializers
                     return BitConverter.ToInt32(bytes, 0);
                 case 8:
                     return BitConverter.ToInt64(bytes, 0);
+                default:
+                    throw new Exception($"Unknown Enum size - {length} bytes");
             }
-
-            throw new Exception($"Unknown Enum size - {length} bytes");
         }
 
         public byte[] Serialize(object type)
@@ -29,7 +29,7 @@ namespace AnySerializer.CustomSerializers
             var integralType = type.GetType().GetEnumUnderlyingType();
             var value = Convert.ChangeType(type, integralType);
             if (integralType == typeof(byte))
-                return new byte[] { (byte)value };
+                return new [] { (byte)value };
             else if (integralType == typeof(sbyte))
                 return BitConverter.GetBytes((sbyte)value);
             else if (integralType == typeof(short))

--- a/AnySerializer/AnySerializer/DeserializerInternal.cs
+++ b/AnySerializer/AnySerializer/DeserializerInternal.cs
@@ -29,7 +29,7 @@ namespace AnySerializer
         /// <param name="ignoreAttributes"></param>
         /// <param name="typeRegistry">Custom type registry</param>
         /// <returns></returns>
-        internal T InspectAndDeserialize<T>(byte[] sourceBytes, int maxDepth, SerializerOptions options, ICollection<object> ignoreAttributes, TypeRegistry typeRegistry = null, ICollection<string> ignorePropertiesOrPaths = null)
+        internal T InspectAndDeserialize<T>(byte[] sourceBytes, uint maxDepth, SerializerOptions options, ICollection<object> ignoreAttributes, TypeRegistry typeRegistry = null, ICollection<string> ignorePropertiesOrPaths = null)
         {
             return (T)InspectAndDeserialize(typeof(T), sourceBytes, maxDepth, options, ignoreAttributes, typeRegistry, ignorePropertiesOrPaths);
         }
@@ -45,7 +45,7 @@ namespace AnySerializer
         /// <param name="ignoreAttributes"></param>
         /// <param name="typeRegistry">Custom type registry</param>
         /// <returns></returns>
-        internal object InspectAndDeserialize(Type type, byte[] sourceBytes, int maxDepth, SerializerOptions options, ICollection<object> ignoreAttributes, TypeRegistry typeRegistry = null, ICollection<string> ignorePropertiesOrPaths = null)
+        internal object InspectAndDeserialize(Type type, byte[] sourceBytes, uint maxDepth, SerializerOptions options, ICollection<object> ignoreAttributes, TypeRegistry typeRegistry = null, ICollection<string> ignorePropertiesOrPaths = null)
         {
             if (sourceBytes == null)
                 return null;

--- a/AnySerializer/AnySerializer/DictionaryComparer.cs
+++ b/AnySerializer/AnySerializer/DictionaryComparer.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace AnySerializer
+{
+    public class DictionaryComparer<TKey, TValue> : IEqualityComparer<IDictionary<TKey, TValue>>
+    {
+        private IEqualityComparer<TValue> valueComparer;
+        public DictionaryComparer(IEqualityComparer<TValue> valueComparer = null)
+        {
+            this.valueComparer = valueComparer ?? EqualityComparer<TValue>.Default;
+        }
+
+        public bool Equals(IDictionary<TKey, TValue> x, IDictionary<TKey, TValue> y)
+        {
+            if (x.Count != y.Count)
+                return false;
+            if (x.Keys.Except(y.Keys).Any())
+                return false;
+            if (y.Keys.Except(x.Keys).Any())
+                return false;
+            foreach (var pair in x)
+                if (!valueComparer.Equals(pair.Value, y[pair.Key]))
+                    return false;
+            return true;
+        }
+
+        public int GetHashCode(IDictionary<TKey, TValue> obj)
+        {
+            return 0;
+        }
+    }
+}

--- a/AnySerializer/AnySerializer/ObjectReferenceTracker.cs
+++ b/AnySerializer/AnySerializer/ObjectReferenceTracker.cs
@@ -1,13 +1,14 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace AnySerializer
 {
     /// <summary>
     /// Tracks object references
     /// </summary>
-    public class ObjectReferenceTracker
+    public class ObjectReferenceTracker : IEquatable<ObjectReferenceTracker>
     {
-        private ushort _currentReferenceId = 0;
+        private ushort _currentReferenceId;
         private readonly Dictionary<int, ObjectReference> _objectTree = new Dictionary<int, ObjectReference>();
 
         public ushort GetNextReferenceId()
@@ -56,27 +57,68 @@ namespace AnySerializer
         {
             return _objectTree[hashCode].Object;
         }
+
+        public override int GetHashCode()
+        {
+            return _objectTree.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+                return false;
+            if (obj.GetType() != typeof(ObjectReferenceTracker))
+                return false;
+            return Equals((ObjectReferenceTracker)obj);
+        }
+
+        public bool Equals(ObjectReferenceTracker other)
+        {
+            if (other == null)
+                return false;
+            var dictionaryComparer = new DictionaryComparer<int, ObjectReference>();
+            return _currentReferenceId == other._currentReferenceId
+                && dictionaryComparer.Equals(_objectTree, other._objectTree);
+        }
     }
 
     /// <summary>
     /// An object reference
     /// </summary>
-    public struct ObjectReference
+    public struct ObjectReference : IEquatable<ObjectReference>
     {
         /// <summary>
         /// The object being referenced
         /// </summary>
-        public object Object;
+        public object Object { get; }
 
         /// <summary>
         /// The unique reference id of the object
         /// </summary>
-        public ushort ReferenceId;
+        public ushort ReferenceId { get; }
 
         public ObjectReference(object obj, ushort referenceId)
         {
             Object = obj;
             ReferenceId = referenceId;
+        }
+
+        public override int GetHashCode()
+        {
+            return Object.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj.GetType() != typeof(ObjectReference))
+                return false;
+            return Equals((ObjectReference)obj);
+        }
+
+        public bool Equals(ObjectReference other)
+        {
+            return ReferenceId == other.ReferenceId
+                && Object == other.Object;
         }
     }
 }

--- a/AnySerializer/AnySerializer/SerializerInternal.cs
+++ b/AnySerializer/AnySerializer/SerializerInternal.cs
@@ -33,7 +33,7 @@ namespace AnySerializer
         /// <param name="ignoreAttributes"></param>
         /// <param name="path"></param>
         /// <returns></returns>
-        internal byte[] InspectAndSerialize(object sourceObject, int maxDepth, SerializerOptions options, ICollection<object> ignoreAttributes, ICollection<string> ignorePropertiesOrPaths = null)
+        internal byte[] InspectAndSerialize(object sourceObject, uint maxDepth, SerializerOptions options, ICollection<object> ignoreAttributes, ICollection<string> ignorePropertiesOrPaths = null)
         {
             if (sourceObject == null)
                 return null;
@@ -75,6 +75,7 @@ namespace AnySerializer
         private byte[] CompressData(byte[] dataBytes)
         {
             var settingsByte = dataBytes[0];
+            var compressedArrayWithSettingsByte = new byte[0];
             var dataBytesWithoutSettingsByte = new byte[dataBytes.Length - 1];
             Array.Copy(dataBytes, 1, dataBytesWithoutSettingsByte, 0, dataBytes.Length - 1);
             using (var compressedStream = new MemoryStream())
@@ -87,12 +88,11 @@ namespace AnySerializer
                     }
                 }
                 var compressedArray = compressedStream.ToArray();
-                var compressedArrayWithSettingsByte = new byte[compressedArray.Length + 1];
+                compressedArrayWithSettingsByte = new byte[compressedArray.Length + 1];
                 compressedArrayWithSettingsByte[0] = settingsByte;
                 Array.Copy(compressedArray, 0, compressedArrayWithSettingsByte, 1, compressedArray.Length);
-                dataBytes = compressedArrayWithSettingsByte;
             }
-            return dataBytes;
+            return compressedArrayWithSettingsByte;
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace AnySerializer
                     var lengthStartPosition = writer.BaseStream.Position;
 
                     // make room for the length prefix
-                    writer.Seek(Constants.LengthHeaderSize + (int)writer.BaseStream.Position, SeekOrigin.Begin);
+                    writer.Seek((int)(Constants.LengthHeaderSize + writer.BaseStream.Position), SeekOrigin.Begin);
 
                     var descriptorBytes = typeDescriptors.Serialize();
                     writer.Write(descriptorBytes, 0, descriptorBytes.Length);

--- a/AnySerializer/AnySerializer/SerializerProvider.cs
+++ b/AnySerializer/AnySerializer/SerializerProvider.cs
@@ -33,9 +33,8 @@ namespace AnySerializer
         /// </summary>
         /// <param name="obj">The object to serialize</param>
         /// <param name="embedTypes">True to embed concrete types in serialization data (increases size)</param>
-        /// <param name="ignorePropertiesOrPaths">List of property names or property paths to ignore</param>
         /// <returns></returns>
-        public byte[] Serialize<T>(T obj, bool embedTypes = false)
+        public byte[] Serialize<T>(T obj, bool embedTypes)
         {
             return Serialize<T>(obj, embedTypes ? SerializerOptions.EmbedTypes : SerializerOptions.None);
         }
@@ -44,7 +43,6 @@ namespace AnySerializer
         /// Serialize an object to a byte array
         /// </summary>
         /// <param name="obj">The object to serialize</param>
-        /// <param name="ignorePropertiesOrPaths">List of property names or property paths to ignore</param>
         /// <returns></returns>
         public byte[] Serialize<T>(T obj)
         {
@@ -431,7 +429,9 @@ namespace AnySerializer
             if (stream.Length == 0)
                 return null;
             var bytes = new byte[stream.Length];
-            stream.Read(bytes, 0, bytes.Length);
+            var bytesRead = stream.Read(bytes, 0, bytes.Length);
+            if (bytesRead < bytes.Length)
+                throw new InvalidOperationException($"The data read ({bytesRead}) was different than the expected bytes to read ({bytes.Length})! This indicates corrupt data.");
 
             return _deserializer.InspectAndDeserialize(type, bytes, Constants.DefaultMaxDepth, options, _ignoreAttributes);
         }

--- a/AnySerializer/AnySerializer/TypeBase.cs
+++ b/AnySerializer/AnySerializer/TypeBase.cs
@@ -9,7 +9,7 @@ namespace AnySerializer
 {
     public class TypeBase
     {
-        protected int _maxDepth;
+        protected uint _maxDepth;
         protected SerializerDataSettings _dataSettings;
         protected SerializerOptions _options;
         protected TypeDescriptors _typeDescriptors;
@@ -29,13 +29,20 @@ namespace AnySerializer
         {
             var ignoreByNameOrPath = _ignorePropertiesOrPaths?.Contains(name) == true || _ignorePropertiesOrPaths?.Contains(path) == true;
             if (ignoreByNameOrPath)
+            {
                 return true;
+            }
 #if FEATURE_CUSTOM_ATTRIBUTES
             if (attributes?.Any(x => !_options.BitwiseHasFlag(SerializerOptions.DisableIgnoreAttributes) && (_ignoreAttributes.Contains(x.AttributeType) || _ignoreAttributes.Contains(x.AttributeType.Name))) == true)
+            {
+                return true;
+            }
 #else
             if (attributes?.Any(x => !_options.BitwiseHasFlag(SerializerOptions.DisableIgnoreAttributes) && (_ignoreAttributes.Contains(x.Constructor.DeclaringType) || _ignoreAttributes.Contains(x.Constructor.DeclaringType.Name))) == true)
-#endif
+            {
                 return true;
+            }
+#endif
             return false;
         }
     }

--- a/AnySerializer/AnySerializer/TypeDescriptors.cs
+++ b/AnySerializer/AnySerializer/TypeDescriptors.cs
@@ -85,7 +85,9 @@ namespace AnySerializer
                     using(var writer = new StreamWriter(lz4Stream))
                     {
                         foreach (var typeDescriptor in Types)
+                        {
                             writer.Write($"{typeDescriptor.TypeId}|{typeDescriptor.FullName}\r\n");
+                        }
                     }
                 }
                 return stream.ToArray();
@@ -107,7 +109,7 @@ namespace AnySerializer
                         string line;
                         while ((line = reader.ReadLine()) != null)
                         {
-                            string[] parts = line.Split(new char[] { '|' }, 2);
+                            var parts = line.Split(new char[] { '|' }, 2);
 
                             Types.Add(new TypeDescriptor(ushort.Parse(parts[0]), parts[1]));
                         }

--- a/AnySerializer/AnySerializer/TypeManagement.cs
+++ b/AnySerializer/AnySerializer/TypeManagement.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Drawing;
 
 namespace AnySerializer
 {
     public static class TypeManagement
     {
-        public static readonly IDictionary<Type, TypeId> TypeMapping = new Dictionary<Type, TypeId> {
+        public static readonly IReadOnlyDictionary<Type, TypeId> TypeMapping = new ReadOnlyDictionary<Type, TypeId>(new Dictionary<Type, TypeId> {
                         { typeof(bool), TypeId.Bool },
                         { typeof(byte), TypeId.Byte },
                         { typeof(sbyte), TypeId.Byte },
@@ -35,7 +36,7 @@ namespace AnySerializer
                         { typeof(IDictionary<,>), TypeId.IDictionary },
                         { typeof(Tuple<,>), TypeId.Tuple },
                         { typeof(KeyValuePair<,>), TypeId.KeyValuePair},
-                    };
+                    });
 
         /// <summary>
         /// The supported serialization data type

--- a/AnySerializer/AnySerializer/TypeReader.cs
+++ b/AnySerializer/AnySerializer/TypeReader.cs
@@ -16,8 +16,8 @@ namespace AnySerializer
 {
     internal class TypeReader : TypeBase
     {
-        private Dictionary<ushort, object> _objectReferences;
-        private TypeRegistry _typeRegistry;
+        private readonly Dictionary<ushort, object> _objectReferences;
+        private readonly TypeRegistry _typeRegistry;
 
         /// <summary>
         /// Read the parent object, and recursively process it's children
@@ -30,7 +30,7 @@ namespace AnySerializer
         /// <param name="ignoreAttributes">Properties/Fields with these attributes will be ignored from processing</param>
         /// <param name="typeRegistry">A registry that contains custom type mappings</param>
         /// <returns></returns>
-        internal static object Read(BinaryReader reader, ExtendedType typeSupport, int maxDepth, SerializerOptions options, ICollection<object> ignoreAttributes, TypeRegistry typeRegistry = null, ICollection<string> ignorePropertiesOrPaths = null)
+        internal static object Read(BinaryReader reader, ExtendedType typeSupport, uint maxDepth, SerializerOptions options, ICollection<object> ignoreAttributes, TypeRegistry typeRegistry = null, ICollection<string> ignorePropertiesOrPaths = null)
         {
             var currentDepth = 0;
             uint dataLength = 0;
@@ -51,7 +51,7 @@ namespace AnySerializer
             return typeReader.ReadObject(dataReader, typeSupport, currentDepth, string.Empty, ref dataLength, ref headerLength);
         }
 
-        public TypeReader(SerializerDataSettings dataSettings, SerializerOptions options, int maxDepth, ICollection<object> ignoreAttributes, TypeRegistry typeRegistry, ICollection<string> ignorePropertiesOrPaths = null)
+        public TypeReader(SerializerDataSettings dataSettings, SerializerOptions options, uint maxDepth, ICollection<object> ignoreAttributes, TypeRegistry typeRegistry, ICollection<string> ignorePropertiesOrPaths = null)
         {
             _dataSettings = dataSettings;
             _options = options;
@@ -60,7 +60,7 @@ namespace AnySerializer
             _ignorePropertiesOrPaths = ignorePropertiesOrPaths;
             _typeRegistry = typeRegistry;
             _objectReferences = new Dictionary<ushort, object>();
-            _customSerializers = new Dictionary<Type, Lazy<ICustomSerializer>>()
+            _customSerializers = new Dictionary<Type, Lazy<ICustomSerializer>>
             {
                 { typeof(Point), new Lazy<ICustomSerializer>(() => new PointSerializer()) },
                 { typeof(Enum), new Lazy<ICustomSerializer>(() => new EnumSerializer()) },
@@ -114,7 +114,6 @@ namespace AnySerializer
             var isNullValue = TypeUtil.IsNullValue((TypeId)objectTypeByte);
             var isTypeMapped = TypeUtil.IsTypeMapped((TypeId)objectTypeByte);
             var isTypeDescriptorMap = TypeUtil.IsTypeDescriptorMap((TypeId)objectTypeByte);
-            var isValueType = TypeUtil.IsValueType(objectTypeId);
 
             // read the length prefix (minus the length field itself)
             if (_dataSettings.BitwiseHasFlag(SerializerDataSettings.Compact))
@@ -196,21 +195,18 @@ namespace AnySerializer
                 if (!TypeUtil.GetTypeId(objectExtendedType).Equals(objectTypeId))
                     throw new DataFormatException($"Serialized data wants to map {objectTypeId} to {typeSupport.Type.Name}, invalid data.");
             }
-            else
-            {
-
-            }
 
             object newObj = null;
+            var destinationTypeSupport = typeSupport; 
             try
             {
                 if (!string.IsNullOrEmpty(typeDescriptor?.FullName))
                 {
                     newObj = objectFactory.CreateEmptyObject(typeDescriptor.FullName, _typeRegistry);
-                    typeSupport = Type.GetType(typeDescriptor.FullName).GetExtendedType();
+                    destinationTypeSupport = Type.GetType(typeDescriptor.FullName).GetExtendedType();
                 }
                 else
-                    newObj = objectFactory.CreateEmptyObject(typeSupport.Type, _typeRegistry);
+                    newObj = objectFactory.CreateEmptyObject(destinationTypeSupport.Type, _typeRegistry);
             }
             catch (InvalidOperationException ex)
             {
@@ -221,48 +217,50 @@ namespace AnySerializer
             var objectDataLength = dataLength;
             var @switch = new Dictionary<Type, Func<object>>
                 {
-                    { typeof(XDocument), () => { return ReadValueType(reader, objectDataLength, typeSupport, currentDepth, path); } },
+                    { typeof(XDocument), () => { return ReadValueType(reader, objectDataLength, destinationTypeSupport, currentDepth, path); } },
                 };
 
-            if (@switch.ContainsKey(typeSupport.Type))
-                newObj = @switch[typeSupport.Type]();
+            if (@switch.ContainsKey(destinationTypeSupport.Type))
+                newObj = @switch[destinationTypeSupport.Type]();
             else
             {
                 switch (objectTypeId)
                 {
                     case TypeId.Object:
-                        newObj = ReadObjectType(newObj, reader, dataLength, typeSupport, currentDepth, path, typeDescriptor);
+                        newObj = ReadObjectType(newObj, reader, dataLength, destinationTypeSupport, currentDepth, path, typeDescriptor);
                         break;
                     case TypeId.Struct:
-                        newObj = ReadStructType(newObj, reader, dataLength, typeSupport, currentDepth, path, typeDescriptor);
+                        newObj = ReadStructType(newObj, reader, dataLength, destinationTypeSupport, currentDepth, path, typeDescriptor);
                         break;
                     case TypeId.Array:
-                        newObj = ReadArrayType(newObj, reader, dataLength, typeSupport, currentDepth, path, typeDescriptor);
+                        newObj = ReadArrayType(newObj, reader, dataLength, destinationTypeSupport, currentDepth, path, typeDescriptor);
                         break;
                     case TypeId.IDictionary:
-                        newObj = ReadDictionaryType(newObj, reader, dataLength, typeSupport, currentDepth, path, typeDescriptor);
+                        newObj = ReadDictionaryType(newObj, reader, dataLength, destinationTypeSupport, currentDepth, path, typeDescriptor);
                         break;
                     case TypeId.IEnumerable:
-                        newObj = ReadEnumerableType(newObj, reader, dataLength, typeSupport, currentDepth, path, typeDescriptor);
+                        newObj = ReadEnumerableType(newObj, reader, dataLength, destinationTypeSupport, currentDepth, path, typeDescriptor);
                         break;
                     case TypeId.KeyValuePair:
-                        newObj = ReadKeyValueType(newObj, reader, dataLength, typeSupport, currentDepth, path, typeDescriptor);
+                        newObj = ReadKeyValueType(newObj, reader, dataLength, destinationTypeSupport, currentDepth, path, typeDescriptor);
                         break;
                     case TypeId.Enum:
                         newObj = ReadValueType(reader, dataLength, new ExtendedType(typeof(Enum)), currentDepth, path);
                         break;
                     case TypeId.Tuple:
-                        newObj = ReadTupleType(newObj, reader, dataLength, typeSupport, currentDepth, path, typeDescriptor);
+                        newObj = ReadTupleType(newObj, reader, dataLength, destinationTypeSupport, currentDepth, path, typeDescriptor);
                         break;
                     default:
-                        newObj = ReadValueType(reader, dataLength, typeSupport, currentDepth, path);
+                        newObj = ReadValueType(reader, dataLength, destinationTypeSupport, currentDepth, path);
                         break;
                 }
             }
 
             // store the object reference id in the object reference map
             if (!_objectReferences.ContainsKey(objectReferenceId))
+            {
                 _objectReferences.Add(objectReferenceId, newObj);
+            }
 
             return newObj;
         }
@@ -324,7 +322,6 @@ namespace AnySerializer
             var genericType = typeSupport.ElementType;
             var listType = typeof(List<>).MakeGenericType(genericType);
             var newList = (IList)Activator.CreateInstance(listType);
-            var enumerator = (IEnumerable)newObj;
             var elementExtendedType = new ExtendedType(typeSupport.ElementType);
             while (i < length)
             {
@@ -334,14 +331,16 @@ namespace AnySerializer
                 newList.Add(element);
             }
 
+            var returnObj = newObj;
+
             // return the value
             if (!string.IsNullOrEmpty(typeDescriptor?.FullName))
-                newObj = new ObjectFactory().CreateEmptyObject(typeDescriptor.FullName, _typeRegistry, length: newList.Count);
+                returnObj = new ObjectFactory().CreateEmptyObject(typeDescriptor.FullName, _typeRegistry, length: newList.Count);
             else
-                newObj = new ObjectFactory().CreateEmptyObject(typeSupport.Type, _typeRegistry, length: newList.Count);
+                returnObj = new ObjectFactory().CreateEmptyObject(typeSupport.Type, _typeRegistry, length: newList.Count);
 
-            newList.CopyTo((Array)newObj, 0);
-            return (Array)newObj;
+            newList.CopyTo((Array)returnObj, 0);
+            return (Array)returnObj;
         }
 
         internal object ReadEnumerableType(object newObj, BinaryReader reader, uint length, ExtendedType typeSupport, int currentDepth, string path, TypeDescriptor typeDescriptor)
@@ -367,7 +366,7 @@ namespace AnySerializer
                 var element = ReadObject(reader, genericExtendedType, currentDepth, path, ref dataLength, ref headerLength);
                 // increment the size of the data read
                 i += dataLength + headerLength;
-                addMethod.Invoke(newObj, new object[] { element });
+                addMethod.Invoke(newObj, new [] { element });
             }
             return newObj;
         }
@@ -391,7 +390,6 @@ namespace AnySerializer
                 newTuple = new ObjectFactory().CreateEmptyObject(typeDescriptor.FullName, _typeRegistry);
             else
                 newTuple = new ObjectFactory().CreateEmptyObject(tupleType, _typeRegistry);
-            newObj = newTuple;
             var index = 0;
             while (i < length)
             {
@@ -399,9 +397,9 @@ namespace AnySerializer
                 // increment the size of the data read
                 i += dataLength + headerLength;
                 if (typeSupport.IsValueTuple)
-                    TypeUtil.SetFieldValue($"Item{index + 1}", newObj, element);
+                    TypeUtil.SetFieldValue($"Item{index + 1}", newTuple, element);
                 else
-                    TypeUtil.SetFieldValue($"m_Item{index + 1}", newObj, element);
+                    TypeUtil.SetFieldValue($"m_Item{index + 1}", newTuple, element);
                 index++;
             }
 
@@ -424,8 +422,6 @@ namespace AnySerializer
 
             var dictionaryType = typeof(Dictionary<,>).MakeGenericType(typeArgs);
             var newDictionary = Activator.CreateInstance(dictionaryType) as IDictionary;
-            newObj = newDictionary;
-            var enumerator = (IDictionary)newObj;
 
             while (i < length)
             {
@@ -443,11 +439,11 @@ namespace AnySerializer
             {
                 dictionaryType = typeof(ConcurrentDictionary<,>).MakeGenericType(typeArgs);
                 var newConcurrentDictionary = Activator.CreateInstance(dictionaryType, new object[] { newDictionary }) as IDictionary;
-                newObj = newConcurrentDictionary;
+                newDictionary = newConcurrentDictionary;
             }
 
             // return the value
-            return newObj;
+            return newDictionary;
         }
 
         internal object ReadKeyValueType(object newObj, BinaryReader reader, uint length, ExtendedType typeSupport, int currentDepth, string path, TypeDescriptor typeDescriptor)
@@ -474,9 +470,10 @@ namespace AnySerializer
             var fields = newObj.GetFields(FieldOptions.AllWritable).Where(x => !x.FieldInfo.IsStatic).OrderBy(x => x.Name);
 
             var rootPath = path;
+            var localPath = path;
             foreach (var field in fields)
             {
-                path = $"{rootPath}.{field.ReflectedType.Name}.{field.Name}";
+                localPath = $"{rootPath}.{field.ReflectedType.Name}.{field.Name}";
                 uint dataLength = 0;
                 uint headerLength = 0;
                 var fieldExtendedType = new ExtendedType(field.Type);
@@ -485,13 +482,13 @@ namespace AnySerializer
                     continue;
 
                 // check for ignore attributes
-                if (IgnoreObjectName(field.Name, path, field.CustomAttributes))
+                if (IgnoreObjectName(field.Name, localPath, field.CustomAttributes))
                     continue;
                 // also check the property for ignore, if this is a auto-backing property
                 if (field.BackedProperty != null && IgnoreObjectName(field.BackedProperty.Name, $"{rootPath}.{field.ReflectedType.Name}.{field.BackedPropertyName}", field.BackedProperty.CustomAttributes))
                     continue;
 
-                var fieldValue = ReadObject(reader, fieldExtendedType, currentDepth, path, ref dataLength, ref headerLength);
+                var fieldValue = ReadObject(reader, fieldExtendedType, currentDepth, localPath, ref dataLength, ref headerLength);
                 newObj.SetFieldValue(field, fieldValue);
             }
 
@@ -504,9 +501,10 @@ namespace AnySerializer
             var fields = newObj.GetFields(FieldOptions.AllWritable).OrderBy(x => x.Name);
 
             var rootPath = path;
+            var localPath = path;
             foreach (var field in fields)
             {
-                path = $"{rootPath}.{field.ReflectedType.Name}.{field.Name}";
+                localPath = $"{rootPath}.{field.ReflectedType.Name}.{field.Name}";
                 uint dataLength = 0;
                 uint headerLength = 0;
                 var fieldExtendedType = new ExtendedType(field.Type);
@@ -515,13 +513,13 @@ namespace AnySerializer
                     continue;
 
                 // check for ignore attributes
-                if (IgnoreObjectName(field.Name, path, field.CustomAttributes))
+                if (IgnoreObjectName(field.Name, localPath, field.CustomAttributes))
                     continue;
                 // also check the property for ignore, if this is a auto-backing property
                 if (field.BackedProperty != null && IgnoreObjectName(field.BackedProperty.Name, $"{rootPath}.{field.ReflectedType.Name}.{field.BackedPropertyName}", field.BackedProperty.CustomAttributes))
                     continue;
 
-                var fieldValue = ReadObject(reader, fieldExtendedType, currentDepth, path, ref dataLength, ref headerLength);
+                var fieldValue = ReadObject(reader, fieldExtendedType, currentDepth, localPath, ref dataLength, ref headerLength);
                 newObj.SetFieldValue(field, fieldValue);
             }
 

--- a/AnySerializer/AnySerializer/TypeUtil.cs
+++ b/AnySerializer/AnySerializer/TypeUtil.cs
@@ -30,9 +30,19 @@ namespace AnySerializer
         /// Get all of the fields of an object
         /// </summary>
         /// <param name="obj"></param>
+        /// <returns></returns>
+        public static ICollection<FieldInfo> GetFields(object obj)
+        {
+            return GetFields(obj, false);
+        }
+
+        /// <summary>
+        /// Get all of the fields of an object
+        /// </summary>
+        /// <param name="obj"></param>
         /// <param name="includeAutoPropertyBackingFields">True to include the compiler generated backing fields for auto-property getters/setters</param>
         /// <returns></returns>
-        public static ICollection<FieldInfo> GetFields(object obj, bool includeAutoPropertyBackingFields = false)
+        public static ICollection<FieldInfo> GetFields(object obj, bool includeAutoPropertyBackingFields)
         {
             if (obj != null)
             {
@@ -142,11 +152,9 @@ namespace AnySerializer
                         field.SetValue(obj, valueToSet);
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                //OnError?.Invoke(ex, path, property, obj);
-                //if (OnError == null)
-                throw ex;
+                throw;
             }
         }
 
@@ -156,11 +164,9 @@ namespace AnySerializer
             {
                 field.SetValue(obj, valueToSet);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                //OnError?.Invoke(ex, path, field, obj);
-                //if (OnError == null)
-                throw ex;
+                throw;
             }
         }
 

--- a/AnySerializer/AnySerializer/ValidatorInternal.cs
+++ b/AnySerializer/AnySerializer/ValidatorInternal.cs
@@ -52,7 +52,7 @@ namespace AnySerializer
                     }
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 isValid = false;
             }

--- a/AnySerializer/AnySerializer/ValidatorInternal.cs
+++ b/AnySerializer/AnySerializer/ValidatorInternal.cs
@@ -70,13 +70,11 @@ namespace AnySerializer
             var isChunkValid = true;
             var objectTypeIdByte = reader.ReadByte();
             var objectTypeId = (TypeId)objectTypeIdByte;
-            var isNullValue = TypeUtil.IsNullValue(objectTypeId);
             var isTypeMapped = TypeUtil.IsTypeMapped(objectTypeId);
             var isTypeDescriptorMap = TypeUtil.IsTypeDescriptorMap(objectTypeId);
 
             // strip the flags and get only the type
             var objectTypeIdOnly = TypeUtil.GetTypeId(objectTypeIdByte);
-            var isValueType = TypeUtil.IsValueType(objectTypeIdOnly);
 
             uint length = 0;
             if(dataSettings.BitwiseHasFlag(SerializerDataSettings.Compact))
@@ -96,9 +94,9 @@ namespace AnySerializer
                 else
                     dataLength = length - sizeof(uint);
                 // read in the type descriptor map
-                typeDescriptors = TypeReader.GetTypeDescriptorMap(reader, dataLength);
+                var typeDescriptorMap = TypeReader.GetTypeDescriptorMap(reader, dataLength);
                 // continue reading the data
-                return ReadChunk(reader, typeDescriptors, dataSettings);
+                return ReadChunk(reader, typeDescriptorMap, dataSettings);
             }
             else
             {
@@ -114,8 +112,6 @@ namespace AnySerializer
                     return false;
             }
 
-            var objectTypeSupport = TypeUtil.GetType(objectTypeIdOnly);
-
             // value type
             if (length > 0)
             {
@@ -126,21 +122,28 @@ namespace AnySerializer
                     case TypeId.Tuple:
                     case TypeId.IDictionary:
                     case TypeId.IEnumerable:
+                    case TypeId.Struct:
+                    case TypeId.Enum:
+                    case TypeId.KeyValuePair:
                     case TypeId.Object:
                         isChunkValid = ReadChunk(reader, typeDescriptors, dataSettings);
+                        if (!isChunkValid)
+                            return false;
+                        break;
+                    default:
+                        // it's not a chunk type, it's a value type
+                        isChunkValid = true;
                         break;
                 }
-                if (!isChunkValid)
-                    return false;
 
                 if(reader.BaseStream.Position - lengthStartPosition - sizeof(ushort) == 0)
                 {
                     // it's a value type, read the full data
                     byte[] data = null;
                     if (dataSettings.BitwiseHasFlag(SerializerDataSettings.Compact))
-                        data = reader.ReadBytes((int)length - Constants.CompactLengthHeaderSize);
+                        data = reader.ReadBytes((int)(length - Constants.CompactLengthHeaderSize));
                     else
-                        data = reader.ReadBytes((int)length - Constants.LengthHeaderSize);
+                        data = reader.ReadBytes((int)(length - Constants.LengthHeaderSize));
                 }
                 else if(reader.BaseStream.Position < reader.BaseStream.Length)
                 {


### PR DESCRIPTION
Fixes #7 - updates compression library to use newer LZ4 maintained library. This will however drop support for compression in .net 4.5 and below.

Also updates code to improve suggestions by static analysis.